### PR TITLE
Making

### DIFF
--- a/Source/ProjectFirma.Web/Common/SitkaController.cs
+++ b/Source/ProjectFirma.Web/Common/SitkaController.cs
@@ -323,6 +323,12 @@ namespace ProjectFirma.Web.Common
             return RedirectToActionStatic(route);
         }
 
+        protected RedirectResult RedirectToActionWithPermanentRedirect<T>(SitkaRoute<T> route) where T : Controller
+        {
+            var redirectToActionStatic = new RedirectResult(route.BuildUrlFromExpression(), true);
+            return redirectToActionStatic;
+        }
+
         protected ActionResult RedirectToActionWithError<T>(SitkaRoute<T> route, string error) where T : Controller
         {
             SetErrorForDisplay(error);
@@ -331,7 +337,8 @@ namespace ProjectFirma.Web.Common
 
         public static RedirectResult RedirectToActionStatic<T>(SitkaRoute<T> route) where T : Controller
         {
-            return new RedirectResult(route.BuildUrlFromExpression());
+            var redirectToActionStatic = new RedirectResult(route.BuildUrlFromExpression()); 
+            return redirectToActionStatic;
         }
 
         protected FileResult ExportGridToExcelImpl(string gridName)

--- a/Source/ProjectFirma.Web/Controllers/CostAuthorityController.cs
+++ b/Source/ProjectFirma.Web/Controllers/CostAuthorityController.cs
@@ -40,6 +40,17 @@ namespace ProjectFirma.Web.Controllers
         [CostAuthorityViewFeature]
         public ActionResult CostAuthorityDetail(string costAuthorityWorkBreakdownStructureString)
         {
+            // If just a pure int, likely an OLD URL where we just took CostAuthorityID.
+            if (int.TryParse(costAuthorityWorkBreakdownStructureString, out var possibleCostAuthorityID))
+            {
+                var possibleCostAuthority = HttpRequestStorage.DatabaseEntities.CostAuthorities.SingleOrDefault(ca => ca.CostAuthorityID == possibleCostAuthorityID);
+                if (possibleCostAuthority != null)
+                {
+                    // We want this to be a permanent redirect since Google is the one hitting us with these old IDs.
+                    return RedirectToActionWithPermanentRedirect(new SitkaRoute<CostAuthorityController>(pc => pc.CostAuthorityDetail(possibleCostAuthority.CostAuthorityWorkBreakdownStructure)));
+                }
+            }
+
             string correctedCawbsString = CostAuthority.CorrectedCostAuthorityWorkBreakdownStructureString(costAuthorityWorkBreakdownStructureString);
             // If they did enter a CAWBS string we could fix, we redirect permanently in case they bookmark
             if (correctedCawbsString != costAuthorityWorkBreakdownStructureString)


### PR DESCRIPTION
CHERRYPICKING this from develop to do a hotfix -- SLG & TK.

https://bor.localhost.projectfirma.com/CostAuthority/CostAuthorityDetail/151

Redirect to

https://bor.localhost.projectfirma.com/CostAuthority/CostAuthorityDetail/A30167868132000100

Google has stale URLs, and this will re-train it over time to use the new ones.