### PR TITLE
Remove delete action item button from editor

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/ActionItemController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ActionItemController.cs
@@ -72,7 +72,7 @@ namespace ProjectFirma.Web.Controllers
                 DueByDate = DateTime.Now
             };
             
-            return ViewEdit(viewModel, null);
+            return ViewEdit(viewModel);
         }
         
         [HttpPost]
@@ -82,7 +82,7 @@ namespace ProjectFirma.Web.Controllers
         {
             if (!ModelState.IsValid)
             {
-                return ViewEdit(viewModel, null);
+                return ViewEdit(viewModel);
             }
             
             var actionItem = new ActionItem(ModelObjectHelpers.NotYetAssignedID, ModelObjectHelpers.NotYetAssignedID, DateTime.Now, DateTime.Now, ModelObjectHelpers.NotYetAssignedID);
@@ -116,7 +116,7 @@ namespace ProjectFirma.Web.Controllers
                 DueByDate = DateTime.Now
             };
 
-            return ViewEdit(viewModel, null);
+            return ViewEdit(viewModel);
         }
 
         [HttpPost]
@@ -126,7 +126,7 @@ namespace ProjectFirma.Web.Controllers
         {
             if (!ModelState.IsValid)
             {
-                return ViewEdit(viewModel, null);
+                return ViewEdit(viewModel);
             }
 
             var actionItem = new ActionItem(ModelObjectHelpers.NotYetAssignedID, ModelObjectHelpers.NotYetAssignedID, DateTime.Now, DateTime.Now, ModelObjectHelpers.NotYetAssignedID);
@@ -151,10 +151,10 @@ namespace ProjectFirma.Web.Controllers
         {
             var actionItem = actionItemPrimaryKey.EntityObject;
             var viewModel = new EditViewModel(actionItem);
-            return ViewEdit(viewModel, actionItem);
+            return ViewEdit(viewModel);
         }
 
-        private PartialViewResult ViewEdit(EditViewModel viewModel, ActionItem actionItem)
+        private PartialViewResult ViewEdit(EditViewModel viewModel)
         {
             var firmaPage = FirmaPageTypeEnum.ActionItemEditDialog.GetFirmaPage();
             var peopleSelectListItems = HttpRequestStorage.DatabaseEntities.People.AsEnumerable()
@@ -165,9 +165,7 @@ namespace ProjectFirma.Web.Controllers
                 ? projectProjectStatuses.AsEnumerable().ToSelectListWithEmptyFirstRow(x => x.ProjectProjectStatusID.ToString(), x => x.GetDropdownDisplayName()) 
                 : new List<SelectListItem>().AsEnumerable();
 
-            var deleteUrl = actionItem == null ? string.Empty : actionItem.GetDeleteUrl();
-
-            var viewData = new EditViewData(CurrentFirmaSession, firmaPage, peopleSelectListItems, projectProjectStatusesSelectListItems, deleteUrl);
+            var viewData = new EditViewData(CurrentFirmaSession, firmaPage, peopleSelectListItems, projectProjectStatusesSelectListItems);
             return RazorPartialView<Edit, EditViewData, EditViewModel>(viewData, viewModel);
         }
 
@@ -179,7 +177,7 @@ namespace ProjectFirma.Web.Controllers
             var actionItem = actionItemPrimaryKey.EntityObject;
             if (!ModelState.IsValid)
             {
-                return ViewEdit(viewModel, actionItem);
+                return ViewEdit(viewModel);
             }
 
             var shouldCreateProjectProjectStatus = IsNewProjectProjectStatusNeeded(viewModel, actionItem);

--- a/Source/ProjectFirma.Web/Views/ActionItem/Edit.cshtml
+++ b/Source/ProjectFirma.Web/Views/ActionItem/Edit.cshtml
@@ -114,9 +114,3 @@
     }
 </div>
 }
-
-<div class="row delete-action-item-button">
-    <div class="col-md-12">
-        @ViewDataTyped.DeleteButton
-    </div>
-</div>

--- a/Source/ProjectFirma.Web/Views/ActionItem/EditViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ActionItem/EditViewData.cs
@@ -20,10 +20,7 @@ Source code is available upon request via <support@sitkatech.com>.
 -----------------------------------------------------------------------*/
 
 using System.Collections.Generic;
-using System.Web;
 using System.Web.Mvc;
-using LtInfo.Common.ModalDialog;
-using ProjectFirma.Web.Models;
 using ProjectFirma.Web.Views.Shared;
 using ProjectFirmaModels.Models;
 
@@ -34,14 +31,12 @@ namespace ProjectFirma.Web.Views.ActionItem
         public ViewPageContentViewData PageContentViewData { get; }
         public IEnumerable<SelectListItem> ProjectProjectStatusSelectListItems { get; }
         public IEnumerable<SelectListItem> PeopleSelectListItems { get; }
-        public HtmlString DeleteButton { get; }
 
-        public EditViewData(FirmaSession currentFirmaSession, ProjectFirmaModels.Models.FirmaPage firmaPage, IEnumerable<SelectListItem> peopleSelectListItems, IEnumerable<SelectListItem> projectProjectStatusSelectListItems, string deleteUrl) : base(currentFirmaSession, firmaPage)
+        public EditViewData(FirmaSession currentFirmaSession, ProjectFirmaModels.Models.FirmaPage firmaPage, IEnumerable<SelectListItem> peopleSelectListItems, IEnumerable<SelectListItem> projectProjectStatusSelectListItems) : base(currentFirmaSession, firmaPage)
         {
             PageContentViewData = new ViewPageContentViewData(firmaPage, true);
             ProjectProjectStatusSelectListItems = projectProjectStatusSelectListItems;
             PeopleSelectListItems = peopleSelectListItems;
-            DeleteButton = string.IsNullOrEmpty(deleteUrl) ? new HtmlString(string.Empty) : ModalDialogFormHelper.MakeDeleteIconButton(deleteUrl, $"Delete {FieldDefinitionEnum.ActionItem.ToType().GetFieldDefinitionLabel()}", true);
         }
     }
 }


### PR DESCRIPTION
Delete button relies on confirmation dialog, which can't be nested.
Can be just as easily deleted from grid, which allows a confirmation
dialog, so just removing the broken button.