### PR TITLE
PF-2498-Developer_Create_Sub-Project_Entity

### DIFF
--- a/Database/ReleaseScript/0736 - PF create subproject Tables.sql
+++ b/Database/ReleaseScript/0736 - PF create subproject Tables.sql
@@ -1,0 +1,124 @@
+CREATE TABLE dbo.Subproject(
+	SubprojectID int identity(1,1) not null,
+	TenantID int not null,
+	ProjectID int not null, 
+	Constraint [FK_Subproject_Tenant_TenantID] Foreign KEY(TenantID) references dbo.Tenant(TenantID),
+	Constraint [FK_Subproject_Project_ProjectID] Foreign KEY(ProjectID) references dbo.Project(ProjectID),
+	Constraint [PK_Subproject_SubprojectID] Primary Key(SubprojectID),
+	ProjectStageID int not null,
+	Constraint [FK_Subproject_ProjectStage_ProjectStageID] Foreign KEY(ProjectStageID) references dbo.ProjectStage(ProjectStageID),
+	ImplementationStartYear int null,
+	CompleteionYear int null,
+	Notes html null,
+	CONSTRAINT [AK_Subproject_SubprojectID_TenantID] UNIQUE NONCLUSTERED 
+	(
+		[SubprojectID] ASC,
+		[TenantID] ASC
+	),
+	constraint FK_Subproject_Project_ProjectID_TenantID foreign key (ProjectID, TenantID) references dbo.Project(ProjectID, TenantID)
+)
+
+create table dbo.SubprojectPerformanceMeasureActual(
+	[SubprojectPerformanceMeasureActualID] [int] IDENTITY(1,1) NOT NULL,
+	[TenantID] [int] NOT NULL,
+	[SubprojectID] [int] NOT NULL,
+	[PerformanceMeasureID] [int] NOT NULL,
+	[ActualValue] [float] NOT NULL,
+	[PerformanceMeasureReportingPeriodID] [int] NOT NULL,
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasure_PerformanceMeasureID] FOREIGN KEY([PerformanceMeasureID]) REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasure_PerformanceMeasureID_TenantID] FOREIGN KEY([PerformanceMeasureID], [TenantID]) REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasureReportingPeriod_PerformanceMeasureReportingPeriodID] FOREIGN KEY([PerformanceMeasureReportingPeriodID]) REFERENCES [dbo].[PerformanceMeasureReportingPeriod] ([PerformanceMeasureReportingPeriodID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasureReportingPeriod_PerformanceMeasureReportingPeriodID_TenantID] FOREIGN KEY([PerformanceMeasureReportingPeriodID], [TenantID]) REFERENCES [dbo].[PerformanceMeasureReportingPeriod] ([PerformanceMeasureReportingPeriodID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActual_Subproject_SubprojectID] FOREIGN KEY([SubprojectID]) REFERENCES [dbo].[Subproject] ([SubprojectID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActual_Subproject_SubprojectID_TenantID] FOREIGN KEY([SubprojectID], [TenantID]) REFERENCES dbo.Subproject([SubprojectID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActual_Tenant_TenantID] FOREIGN KEY([TenantID]) REFERENCES [dbo].[Tenant] ([TenantID]),
+	CONSTRAINT [PK_SubprojectPerformanceMeasureActual_SubprojectPerformanceMeasureActualID] PRIMARY KEY CLUSTERED 
+	(
+		[SubprojectPerformanceMeasureActualID] ASC
+	),
+	 CONSTRAINT [AK_SubprojectPerformanceMeasureActual_SubprojectPerformanceMeasureActualID_PerformanceMeasureID] UNIQUE NONCLUSTERED 
+	(
+		[SubprojectPerformanceMeasureActualID] ASC,
+		[PerformanceMeasureID] ASC
+	),
+	 CONSTRAINT [AK_SubprojectPerformanceMeasureActual_SubprojectPerformanceMeasureActualID_TenantID] UNIQUE NONCLUSTERED 
+	(
+		[SubprojectPerformanceMeasureActualID] ASC,
+		[TenantID] ASC
+	)
+)
+
+create table dbo.SubprojectPerformanceMeasureExpected(
+	[SubprojectPerformanceMeasureExpectedID] [int] IDENTITY(1,1) NOT NULL,
+	[TenantID] [int] NOT NULL,
+	[SubprojectID] [int] NOT NULL,
+	[PerformanceMeasureID] [int] NOT NULL,
+	[ExpectedValue] [float] NULL,
+	CONSTRAINT [PK_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpectedID] PRIMARY KEY CLUSTERED 
+	(
+		[SubprojectPerformanceMeasureExpectedID] ASC
+	),
+	 CONSTRAINT [AK_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpectedID_PerformanceMeasureID] UNIQUE NONCLUSTERED 
+	(
+		[SubprojectPerformanceMeasureExpectedID] ASC,
+		[PerformanceMeasureID] ASC
+	),
+	 CONSTRAINT [AK_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpectedID_TenantID] UNIQUE NONCLUSTERED 
+	(
+		[SubprojectPerformanceMeasureExpectedID] ASC,
+		[TenantID] ASC
+	),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_PerformanceMeasure_PerformanceMeasureID] FOREIGN KEY([PerformanceMeasureID]) REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_PerformanceMeasure_PerformanceMeasureID_TenantID] FOREIGN KEY([PerformanceMeasureID], [TenantID]) REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_Subproject_SubprojectID] FOREIGN KEY([SubprojectID]) REFERENCES [dbo].[Subproject] ([SubprojectID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_Subproject_SubprojectID_TenantID] FOREIGN KEY([SubprojectID], [TenantID]) REFERENCES [dbo].[Subproject] ([SubprojectID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_Tenant_TenantID] FOREIGN KEY([TenantID]) REFERENCES [dbo].[Tenant] ([TenantID]),
+)
+
+CREATE TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption](
+	[SubprojectPerformanceMeasureActualSubcategoryOptionID] [int] IDENTITY(1,1) NOT NULL,
+	[TenantID] [int] NOT NULL,
+	[SubprojectPerformanceMeasureActualID] [int] NOT NULL,
+	[PerformanceMeasureSubcategoryOptionID] [int] NOT NULL,
+	[PerformanceMeasureID] [int] NOT NULL,
+	[PerformanceMeasureSubcategoryID] [int] NOT NULL,
+	CONSTRAINT [PK_SubprojectPerformanceMeasureActualSubcategoryOption_SubprojectPerformanceMeasureActualSubcategoryOptionID] PRIMARY KEY CLUSTERED 
+	(
+		[SubprojectPerformanceMeasureActualSubcategoryOptionID] ASC
+	),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasure_PerformanceMeasureID] FOREIGN KEY([PerformanceMeasureID]) REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasure_PerformanceMeasureID_TenantID] FOREIGN KEY([PerformanceMeasureID], [TenantID]) REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureActual_SubprojectPerformanceMeasureActualID_Performanc1] FOREIGN KEY([SubprojectPerformanceMeasureActualID]) REFERENCES [dbo].[PerformanceMeasureActual] ([PerformanceMeasureActualID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureActual_SubprojectPerformanceMeasureActualID_Performanc2] FOREIGN KEY([SubprojectPerformanceMeasureActualID], [PerformanceMeasureID]) REFERENCES [dbo].[PerformanceMeasureActual] ([PerformanceMeasureActualID], [PerformanceMeasureID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureActual_SubprojectPerformanceMeasureActualID_TenantID_Pe] FOREIGN KEY([SubprojectPerformanceMeasureActualID], [TenantID]) REFERENCES [dbo].[PerformanceMeasureActual] ([PerformanceMeasureActualID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID] FOREIGN KEY([PerformanceMeasureSubcategoryID]) REFERENCES [dbo].[PerformanceMeasureSubcategory] ([PerformanceMeasureSubcategoryID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID_Performance] FOREIGN KEY([PerformanceMeasureSubcategoryID], [PerformanceMeasureID]) REFERENCES [dbo].[PerformanceMeasureSubcategory] ([PerformanceMeasureSubcategoryID], [PerformanceMeasureID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID_TenantID] FOREIGN KEY([PerformanceMeasureSubcategoryID], [TenantID]) REFERENCES [dbo].[PerformanceMeasureSubcategory] ([PerformanceMeasureSubcategoryID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptionI1] FOREIGN KEY([PerformanceMeasureSubcategoryOptionID]) REFERENCES [dbo].[PerformanceMeasureSubcategoryOption] ([PerformanceMeasureSubcategoryOptionID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptionI2] FOREIGN KEY([PerformanceMeasureSubcategoryOptionID], [PerformanceMeasureSubcategoryID]) REFERENCES [dbo].[PerformanceMeasureSubcategoryOption] ([PerformanceMeasureSubcategoryOptionID], [PerformanceMeasureSubcategoryID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptionI3] FOREIGN KEY([PerformanceMeasureSubcategoryOptionID], [TenantID]) REFERENCES [dbo].[PerformanceMeasureSubcategoryOption] ([PerformanceMeasureSubcategoryOptionID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_Tenant_TenantID] FOREIGN KEY([TenantID]) REFERENCES [dbo].[Tenant] ([TenantID])
+)
+
+CREATE TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption](
+	[SubprojectPerformanceMeasureExpectedSubcategoryOptionID] [int] IDENTITY(1,1) NOT NULL,
+	[TenantID] [int] NOT NULL,
+	[SubprojectPerformanceMeasureExpectedID] [int] NOT NULL,
+	[PerformanceMeasureSubcategoryOptionID] [int] NOT NULL,
+	[PerformanceMeasureID] [int] NOT NULL,
+	[PerformanceMeasureSubcategoryID] [int] NOT NULL,
+	 CONSTRAINT [PK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpectedSubcategoryOptionID] PRIMARY KEY CLUSTERED 
+	(
+		[SubprojectPerformanceMeasureExpectedSubcategoryOptionID] ASC
+	),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasure_PerformanceMeasureID] FOREIGN KEY([PerformanceMeasureID]) REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasure_PerformanceMeasureID_TenantID] FOREIGN KEY([PerformanceMeasureID], [TenantID])REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpec1] FOREIGN KEY([SubprojectPerformanceMeasureExpectedID]) REFERENCES[dbo].[SubprojectPerformanceMeasureExpected] ([SubprojectPerformanceMeasureExpectedID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpec2] FOREIGN KEY([SubprojectPerformanceMeasureExpectedID], [PerformanceMeasureID]) REFERENCES[dbo].[SubprojectPerformanceMeasureExpected] ([SubprojectPerformanceMeasureExpectedID], [PerformanceMeasureID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpec3] FOREIGN KEY([SubprojectPerformanceMeasureExpectedID], [TenantID]) REFERENCES[dbo].[SubprojectPerformanceMeasureExpected] ([SubprojectPerformanceMeasureExpectedID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID] FOREIGN KEY([PerformanceMeasureSubcategoryID]) REFERENCES[dbo].[PerformanceMeasureSubcategory] ([PerformanceMeasureSubcategoryID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID_TenantID] FOREIGN KEY([PerformanceMeasureSubcategoryID], [TenantID]) REFERENCES[dbo].[PerformanceMeasureSubcategory] ([PerformanceMeasureSubcategoryID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptio1] FOREIGN KEY([PerformanceMeasureSubcategoryOptionID]) REFERENCES[dbo].[PerformanceMeasureSubcategoryOption] ([PerformanceMeasureSubcategoryOptionID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptio2] FOREIGN KEY([PerformanceMeasureSubcategoryOptionID], [TenantID]) REFERENCES[dbo].[PerformanceMeasureSubcategoryOption] ([PerformanceMeasureSubcategoryOptionID], [TenantID]),
+	CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_Tenant_TenantID] FOREIGN KEY([TenantID]) REFERENCES[dbo].[Tenant] ([TenantID])
+)

--- a/Database/Tables/dbo.Subproject.sql
+++ b/Database/Tables/dbo.Subproject.sql
@@ -1,0 +1,43 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[Subproject](
+	[SubprojectID] [int] IDENTITY(1,1) NOT NULL,
+	[TenantID] [int] NOT NULL,
+	[ProjectID] [int] NOT NULL,
+	[ProjectStageID] [int] NOT NULL,
+	[ImplementationStartYear] [int] NULL,
+	[CompleteionYear] [int] NULL,
+	[Notes] [dbo].[html] NULL,
+ CONSTRAINT [PK_Subproject_SubprojectID] PRIMARY KEY CLUSTERED 
+(
+	[SubprojectID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY],
+ CONSTRAINT [AK_Subproject_SubprojectID_TenantID] UNIQUE NONCLUSTERED 
+(
+	[SubprojectID] ASC,
+	[TenantID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+
+GO
+ALTER TABLE [dbo].[Subproject]  WITH CHECK ADD  CONSTRAINT [FK_Subproject_Project_ProjectID] FOREIGN KEY([ProjectID])
+REFERENCES [dbo].[Project] ([ProjectID])
+GO
+ALTER TABLE [dbo].[Subproject] CHECK CONSTRAINT [FK_Subproject_Project_ProjectID]
+GO
+ALTER TABLE [dbo].[Subproject]  WITH CHECK ADD  CONSTRAINT [FK_Subproject_Project_ProjectID_TenantID] FOREIGN KEY([ProjectID], [TenantID])
+REFERENCES [dbo].[Project] ([ProjectID], [TenantID])
+GO
+ALTER TABLE [dbo].[Subproject] CHECK CONSTRAINT [FK_Subproject_Project_ProjectID_TenantID]
+GO
+ALTER TABLE [dbo].[Subproject]  WITH CHECK ADD  CONSTRAINT [FK_Subproject_ProjectStage_ProjectStageID] FOREIGN KEY([ProjectStageID])
+REFERENCES [dbo].[ProjectStage] ([ProjectStageID])
+GO
+ALTER TABLE [dbo].[Subproject] CHECK CONSTRAINT [FK_Subproject_ProjectStage_ProjectStageID]
+GO
+ALTER TABLE [dbo].[Subproject]  WITH CHECK ADD  CONSTRAINT [FK_Subproject_Tenant_TenantID] FOREIGN KEY([TenantID])
+REFERENCES [dbo].[Tenant] ([TenantID])
+GO
+ALTER TABLE [dbo].[Subproject] CHECK CONSTRAINT [FK_Subproject_Tenant_TenantID]

--- a/Database/Tables/dbo.SubprojectPerformanceMeasureActual.sql
+++ b/Database/Tables/dbo.SubprojectPerformanceMeasureActual.sql
@@ -1,0 +1,62 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[SubprojectPerformanceMeasureActual](
+	[SubprojectPerformanceMeasureActualID] [int] IDENTITY(1,1) NOT NULL,
+	[TenantID] [int] NOT NULL,
+	[SubprojectID] [int] NOT NULL,
+	[PerformanceMeasureID] [int] NOT NULL,
+	[ActualValue] [float] NOT NULL,
+	[PerformanceMeasureReportingPeriodID] [int] NOT NULL,
+ CONSTRAINT [PK_SubprojectPerformanceMeasureActual_SubprojectPerformanceMeasureActualID] PRIMARY KEY CLUSTERED 
+(
+	[SubprojectPerformanceMeasureActualID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY],
+ CONSTRAINT [AK_SubprojectPerformanceMeasureActual_SubprojectPerformanceMeasureActualID_PerformanceMeasureID] UNIQUE NONCLUSTERED 
+(
+	[SubprojectPerformanceMeasureActualID] ASC,
+	[PerformanceMeasureID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY],
+ CONSTRAINT [AK_SubprojectPerformanceMeasureActual_SubprojectPerformanceMeasureActualID_TenantID] UNIQUE NONCLUSTERED 
+(
+	[SubprojectPerformanceMeasureActualID] ASC,
+	[TenantID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasure_PerformanceMeasureID] FOREIGN KEY([PerformanceMeasureID])
+REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasure_PerformanceMeasureID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasure_PerformanceMeasureID_TenantID] FOREIGN KEY([PerformanceMeasureID], [TenantID])
+REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasure_PerformanceMeasureID_TenantID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasureReportingPeriod_PerformanceMeasureReportingPeriodID] FOREIGN KEY([PerformanceMeasureReportingPeriodID])
+REFERENCES [dbo].[PerformanceMeasureReportingPeriod] ([PerformanceMeasureReportingPeriodID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasureReportingPeriod_PerformanceMeasureReportingPeriodID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasureReportingPeriod_PerformanceMeasureReportingPeriodID_TenantID] FOREIGN KEY([PerformanceMeasureReportingPeriodID], [TenantID])
+REFERENCES [dbo].[PerformanceMeasureReportingPeriod] ([PerformanceMeasureReportingPeriodID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActual_PerformanceMeasureReportingPeriod_PerformanceMeasureReportingPeriodID_TenantID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActual_Subproject_SubprojectID] FOREIGN KEY([SubprojectID])
+REFERENCES [dbo].[Subproject] ([SubprojectID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActual_Subproject_SubprojectID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActual_Subproject_SubprojectID_TenantID] FOREIGN KEY([SubprojectID], [TenantID])
+REFERENCES [dbo].[Subproject] ([SubprojectID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActual_Subproject_SubprojectID_TenantID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActual_Tenant_TenantID] FOREIGN KEY([TenantID])
+REFERENCES [dbo].[Tenant] ([TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActual] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActual_Tenant_TenantID]

--- a/Database/Tables/dbo.SubprojectPerformanceMeasureActualSubcategoryOption.sql
+++ b/Database/Tables/dbo.SubprojectPerformanceMeasureActualSubcategoryOption.sql
@@ -1,0 +1,77 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption](
+	[SubprojectPerformanceMeasureActualSubcategoryOptionID] [int] IDENTITY(1,1) NOT NULL,
+	[TenantID] [int] NOT NULL,
+	[SubprojectPerformanceMeasureActualID] [int] NOT NULL,
+	[PerformanceMeasureSubcategoryOptionID] [int] NOT NULL,
+	[PerformanceMeasureID] [int] NOT NULL,
+	[PerformanceMeasureSubcategoryID] [int] NOT NULL,
+ CONSTRAINT [PK_SubprojectPerformanceMeasureActualSubcategoryOption_SubprojectPerformanceMeasureActualSubcategoryOptionID] PRIMARY KEY CLUSTERED 
+(
+	[SubprojectPerformanceMeasureActualSubcategoryOptionID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasure_PerformanceMeasureID] FOREIGN KEY([PerformanceMeasureID])
+REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasure_PerformanceMeasureID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasure_PerformanceMeasureID_TenantID] FOREIGN KEY([PerformanceMeasureID], [TenantID])
+REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasure_PerformanceMeasureID_TenantID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureActual_SubprojectPerformanceMeasureActualID_Performanc1] FOREIGN KEY([SubprojectPerformanceMeasureActualID])
+REFERENCES [dbo].[PerformanceMeasureActual] ([PerformanceMeasureActualID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureActual_SubprojectPerformanceMeasureActualID_Performanc1]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureActual_SubprojectPerformanceMeasureActualID_Performanc2] FOREIGN KEY([SubprojectPerformanceMeasureActualID], [PerformanceMeasureID])
+REFERENCES [dbo].[PerformanceMeasureActual] ([PerformanceMeasureActualID], [PerformanceMeasureID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureActual_SubprojectPerformanceMeasureActualID_Performanc2]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureActual_SubprojectPerformanceMeasureActualID_TenantID_Pe] FOREIGN KEY([SubprojectPerformanceMeasureActualID], [TenantID])
+REFERENCES [dbo].[PerformanceMeasureActual] ([PerformanceMeasureActualID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureActual_SubprojectPerformanceMeasureActualID_TenantID_Pe]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID] FOREIGN KEY([PerformanceMeasureSubcategoryID])
+REFERENCES [dbo].[PerformanceMeasureSubcategory] ([PerformanceMeasureSubcategoryID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID_Performance] FOREIGN KEY([PerformanceMeasureSubcategoryID], [PerformanceMeasureID])
+REFERENCES [dbo].[PerformanceMeasureSubcategory] ([PerformanceMeasureSubcategoryID], [PerformanceMeasureID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID_Performance]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID_TenantID] FOREIGN KEY([PerformanceMeasureSubcategoryID], [TenantID])
+REFERENCES [dbo].[PerformanceMeasureSubcategory] ([PerformanceMeasureSubcategoryID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID_TenantID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptionI1] FOREIGN KEY([PerformanceMeasureSubcategoryOptionID])
+REFERENCES [dbo].[PerformanceMeasureSubcategoryOption] ([PerformanceMeasureSubcategoryOptionID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptionI1]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptionI2] FOREIGN KEY([PerformanceMeasureSubcategoryOptionID], [PerformanceMeasureSubcategoryID])
+REFERENCES [dbo].[PerformanceMeasureSubcategoryOption] ([PerformanceMeasureSubcategoryOptionID], [PerformanceMeasureSubcategoryID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptionI2]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptionI3] FOREIGN KEY([PerformanceMeasureSubcategoryOptionID], [TenantID])
+REFERENCES [dbo].[PerformanceMeasureSubcategoryOption] ([PerformanceMeasureSubcategoryOptionID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptionI3]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_Tenant_TenantID] FOREIGN KEY([TenantID])
+REFERENCES [dbo].[Tenant] ([TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureActualSubcategoryOption_Tenant_TenantID]

--- a/Database/Tables/dbo.SubprojectPerformanceMeasureExpected.sql
+++ b/Database/Tables/dbo.SubprojectPerformanceMeasureExpected.sql
@@ -1,0 +1,51 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[SubprojectPerformanceMeasureExpected](
+	[SubprojectPerformanceMeasureExpectedID] [int] IDENTITY(1,1) NOT NULL,
+	[TenantID] [int] NOT NULL,
+	[SubprojectID] [int] NOT NULL,
+	[PerformanceMeasureID] [int] NOT NULL,
+	[ExpectedValue] [float] NULL,
+ CONSTRAINT [PK_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpectedID] PRIMARY KEY CLUSTERED 
+(
+	[SubprojectPerformanceMeasureExpectedID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY],
+ CONSTRAINT [AK_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpectedID_PerformanceMeasureID] UNIQUE NONCLUSTERED 
+(
+	[SubprojectPerformanceMeasureExpectedID] ASC,
+	[PerformanceMeasureID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY],
+ CONSTRAINT [AK_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpectedID_TenantID] UNIQUE NONCLUSTERED 
+(
+	[SubprojectPerformanceMeasureExpectedID] ASC,
+	[TenantID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpected]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_PerformanceMeasure_PerformanceMeasureID] FOREIGN KEY([PerformanceMeasureID])
+REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpected] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_PerformanceMeasure_PerformanceMeasureID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpected]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_PerformanceMeasure_PerformanceMeasureID_TenantID] FOREIGN KEY([PerformanceMeasureID], [TenantID])
+REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpected] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_PerformanceMeasure_PerformanceMeasureID_TenantID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpected]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_Subproject_SubprojectID] FOREIGN KEY([SubprojectID])
+REFERENCES [dbo].[Subproject] ([SubprojectID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpected] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_Subproject_SubprojectID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpected]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_Subproject_SubprojectID_TenantID] FOREIGN KEY([SubprojectID], [TenantID])
+REFERENCES [dbo].[Subproject] ([SubprojectID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpected] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_Subproject_SubprojectID_TenantID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpected]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_Tenant_TenantID] FOREIGN KEY([TenantID])
+REFERENCES [dbo].[Tenant] ([TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpected] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpected_Tenant_TenantID]

--- a/Database/Tables/dbo.SubprojectPerformanceMeasureExpectedSubcategoryOption.sql
+++ b/Database/Tables/dbo.SubprojectPerformanceMeasureExpectedSubcategoryOption.sql
@@ -1,0 +1,67 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption](
+	[SubprojectPerformanceMeasureExpectedSubcategoryOptionID] [int] IDENTITY(1,1) NOT NULL,
+	[TenantID] [int] NOT NULL,
+	[SubprojectPerformanceMeasureExpectedID] [int] NOT NULL,
+	[PerformanceMeasureSubcategoryOptionID] [int] NOT NULL,
+	[PerformanceMeasureID] [int] NOT NULL,
+	[PerformanceMeasureSubcategoryID] [int] NOT NULL,
+ CONSTRAINT [PK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpectedSubcategoryOptionID] PRIMARY KEY CLUSTERED 
+(
+	[SubprojectPerformanceMeasureExpectedSubcategoryOptionID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasure_PerformanceMeasureID] FOREIGN KEY([PerformanceMeasureID])
+REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasure_PerformanceMeasureID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasure_PerformanceMeasureID_TenantID] FOREIGN KEY([PerformanceMeasureID], [TenantID])
+REFERENCES [dbo].[PerformanceMeasure] ([PerformanceMeasureID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasure_PerformanceMeasureID_TenantID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID] FOREIGN KEY([PerformanceMeasureSubcategoryID])
+REFERENCES [dbo].[PerformanceMeasureSubcategory] ([PerformanceMeasureSubcategoryID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID_TenantID] FOREIGN KEY([PerformanceMeasureSubcategoryID], [TenantID])
+REFERENCES [dbo].[PerformanceMeasureSubcategory] ([PerformanceMeasureSubcategoryID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID_TenantID]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptio1] FOREIGN KEY([PerformanceMeasureSubcategoryOptionID])
+REFERENCES [dbo].[PerformanceMeasureSubcategoryOption] ([PerformanceMeasureSubcategoryOptionID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptio1]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptio2] FOREIGN KEY([PerformanceMeasureSubcategoryOptionID], [TenantID])
+REFERENCES [dbo].[PerformanceMeasureSubcategoryOption] ([PerformanceMeasureSubcategoryOptionID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptio2]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpec1] FOREIGN KEY([SubprojectPerformanceMeasureExpectedID])
+REFERENCES [dbo].[SubprojectPerformanceMeasureExpected] ([SubprojectPerformanceMeasureExpectedID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpec1]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpec2] FOREIGN KEY([SubprojectPerformanceMeasureExpectedID], [PerformanceMeasureID])
+REFERENCES [dbo].[SubprojectPerformanceMeasureExpected] ([SubprojectPerformanceMeasureExpectedID], [PerformanceMeasureID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpec2]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpec3] FOREIGN KEY([SubprojectPerformanceMeasureExpectedID], [TenantID])
+REFERENCES [dbo].[SubprojectPerformanceMeasureExpected] ([SubprojectPerformanceMeasureExpectedID], [TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpec3]
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]  WITH CHECK ADD  CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_Tenant_TenantID] FOREIGN KEY([TenantID])
+REFERENCES [dbo].[Tenant] ([TenantID])
+GO
+ALTER TABLE [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption] CHECK CONSTRAINT [FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_Tenant_TenantID]

--- a/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
+++ b/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
@@ -288,6 +288,8 @@
     <Compile Include="Models\ProjectExpenditureByCostType.cs" />
     <Compile Include="ReportTemplates\ReportTemplateTests.cs" />
     <Compile Include="ScheduledJobs\CleanUpStaleFirmaSessionsJob.cs" />
+    <Compile Include="Security\SubprojectViewFeature.cs" />
+    <Compile Include="Security\SubprojectManageFeature.cs" />
     <Compile Include="Security\AttachmentTypeManageFeature.cs" />
     <Compile Include="Security\AttachmentTypeViewFeature.cs" />
     <Compile Include="Security\ActionItemAdminFeature.cs" />

--- a/Source/ProjectFirma.Web/Security/SubprojectManageFeature.cs
+++ b/Source/ProjectFirma.Web/Security/SubprojectManageFeature.cs
@@ -1,0 +1,12 @@
+﻿using ProjectFirmaModels.Models;
+using System.Collections.Generic;
+
+
+namespace ProjectFirma.Web.Security
+{
+    [SecurityFeatureDescription("Manage Subproject")]
+    public class SubprojectManageFeature : FirmaFeature
+    {
+        public SubprojectManageFeature() : base(new List<Role> { Role.SitkaAdmin, Role.Admin, Role.ProjectSteward }) { }
+    }
+}

--- a/Source/ProjectFirma.Web/Security/SubprojectViewFeature.cs
+++ b/Source/ProjectFirma.Web/Security/SubprojectViewFeature.cs
@@ -1,0 +1,31 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="SubprojectViewFeature.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+
+using ProjectFirmaModels.Models;
+using ProjectFirma.Web.Security.Shared;
+
+namespace ProjectFirma.Web.Security
+{
+    [SecurityFeatureDescription("View Subproject")]
+    public class SubprojectViewFeature : AnonymousUnclassifiedFeature
+    {
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/DatabaseEntities.Context.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/DatabaseEntities.Context.Binding.cs
@@ -193,6 +193,11 @@ namespace ProjectFirmaModels.Models
             modelBuilder.Configurations.Add(new SolicitationConfiguration());
             modelBuilder.Configurations.Add(new StateProvinceConfiguration());
             modelBuilder.Configurations.Add(new SubbasinLiasonConfiguration());
+            modelBuilder.Configurations.Add(new SubprojectConfiguration());
+            modelBuilder.Configurations.Add(new SubprojectPerformanceMeasureActualConfiguration());
+            modelBuilder.Configurations.Add(new SubprojectPerformanceMeasureActualSubcategoryOptionConfiguration());
+            modelBuilder.Configurations.Add(new SubprojectPerformanceMeasureExpectedConfiguration());
+            modelBuilder.Configurations.Add(new SubprojectPerformanceMeasureExpectedSubcategoryOptionConfiguration());
             modelBuilder.Configurations.Add(new SupportRequestLogConfiguration());
             modelBuilder.Configurations.Add(new TagConfiguration());
             modelBuilder.Configurations.Add(new TaxonomyBranchConfiguration());
@@ -605,6 +610,16 @@ namespace ProjectFirmaModels.Models
         public virtual DbSet<SubbasinLiason> AllSubbasinLiasons { get; set; }
         public virtual IQueryable<SubbasinLiason> SubbasinLiasons { get { return AllSubbasinLiasons.Where(x => x.TenantID == TenantID); } }
         public virtual DbSet<Subbasin> Subbasins { get; set; }
+        public virtual DbSet<SubprojectPerformanceMeasureActual> AllSubprojectPerformanceMeasureActuals { get; set; }
+        public virtual IQueryable<SubprojectPerformanceMeasureActual> SubprojectPerformanceMeasureActuals { get { return AllSubprojectPerformanceMeasureActuals.Where(x => x.TenantID == TenantID); } }
+        public virtual DbSet<SubprojectPerformanceMeasureActualSubcategoryOption> AllSubprojectPerformanceMeasureActualSubcategoryOptions { get; set; }
+        public virtual IQueryable<SubprojectPerformanceMeasureActualSubcategoryOption> SubprojectPerformanceMeasureActualSubcategoryOptions { get { return AllSubprojectPerformanceMeasureActualSubcategoryOptions.Where(x => x.TenantID == TenantID); } }
+        public virtual DbSet<SubprojectPerformanceMeasureExpected> AllSubprojectPerformanceMeasureExpecteds { get; set; }
+        public virtual IQueryable<SubprojectPerformanceMeasureExpected> SubprojectPerformanceMeasureExpecteds { get { return AllSubprojectPerformanceMeasureExpecteds.Where(x => x.TenantID == TenantID); } }
+        public virtual DbSet<SubprojectPerformanceMeasureExpectedSubcategoryOption> AllSubprojectPerformanceMeasureExpectedSubcategoryOptions { get; set; }
+        public virtual IQueryable<SubprojectPerformanceMeasureExpectedSubcategoryOption> SubprojectPerformanceMeasureExpectedSubcategoryOptions { get { return AllSubprojectPerformanceMeasureExpectedSubcategoryOptions.Where(x => x.TenantID == TenantID); } }
+        public virtual DbSet<Subproject> AllSubprojects { get; set; }
+        public virtual IQueryable<Subproject> Subprojects { get { return AllSubprojects.Where(x => x.TenantID == TenantID); } }
         public virtual DbSet<SupportRequestLog> AllSupportRequestLogs { get; set; }
         public virtual IQueryable<SupportRequestLog> SupportRequestLogs { get { return AllSupportRequestLogs.Where(x => x.TenantID == TenantID); } }
         public virtual DbSet<Tag> AllTags { get; set; }
@@ -1471,6 +1486,21 @@ namespace ProjectFirmaModels.Models
 
                 case "Subbasin":
                     return Subbasins.GetSubbasin(primaryKey);
+
+                case "SubprojectPerformanceMeasureActual":
+                    return SubprojectPerformanceMeasureActuals.GetSubprojectPerformanceMeasureActual(primaryKey);
+
+                case "SubprojectPerformanceMeasureActualSubcategoryOption":
+                    return SubprojectPerformanceMeasureActualSubcategoryOptions.GetSubprojectPerformanceMeasureActualSubcategoryOption(primaryKey);
+
+                case "SubprojectPerformanceMeasureExpected":
+                    return SubprojectPerformanceMeasureExpecteds.GetSubprojectPerformanceMeasureExpected(primaryKey);
+
+                case "SubprojectPerformanceMeasureExpectedSubcategoryOption":
+                    return SubprojectPerformanceMeasureExpectedSubcategoryOptions.GetSubprojectPerformanceMeasureExpectedSubcategoryOption(primaryKey);
+
+                case "Subproject":
+                    return Subprojects.GetSubproject(primaryKey);
 
                 case "SupportRequestLog":
                     return SupportRequestLogs.GetSupportRequestLog(primaryKey);

--- a/Source/ProjectFirmaModels/Models/Generated/PerformanceMeasure.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/PerformanceMeasure.Binding.cs
@@ -43,6 +43,10 @@ namespace ProjectFirmaModels.Models
             this.PerformanceMeasureNotes = new HashSet<PerformanceMeasureNote>();
             this.PerformanceMeasureReportingPeriodTargets = new HashSet<PerformanceMeasureReportingPeriodTarget>();
             this.PerformanceMeasureSubcategories = new HashSet<PerformanceMeasureSubcategory>();
+            this.SubprojectPerformanceMeasureActuals = new HashSet<SubprojectPerformanceMeasureActual>();
+            this.SubprojectPerformanceMeasureActualSubcategoryOptions = new HashSet<SubprojectPerformanceMeasureActualSubcategoryOption>();
+            this.SubprojectPerformanceMeasureExpecteds = new HashSet<SubprojectPerformanceMeasureExpected>();
+            this.SubprojectPerformanceMeasureExpectedSubcategoryOptions = new HashSet<SubprojectPerformanceMeasureExpectedSubcategoryOption>();
             this.TaxonomyLeafPerformanceMeasures = new HashSet<TaxonomyLeafPerformanceMeasure>();
         }
 
@@ -117,7 +121,7 @@ namespace ProjectFirmaModels.Models
         /// <returns></returns>
         public bool HasDependentObjects()
         {
-            return ClassificationPerformanceMeasures.Any() || GeospatialAreaPerformanceMeasureFixedTargets.Any() || GeospatialAreaPerformanceMeasureNoTargets.Any() || GeospatialAreaPerformanceMeasureReportingPeriodTargets.Any() || MatchmakerOrganizationPerformanceMeasures.Any() || PerformanceMeasureActuals.Any() || PerformanceMeasureActualSubcategoryOptions.Any() || PerformanceMeasureActualSubcategoryOptionUpdates.Any() || PerformanceMeasureActualUpdates.Any() || PerformanceMeasureExpecteds.Any() || PerformanceMeasureExpectedSubcategoryOptions.Any() || PerformanceMeasureExpectedSubcategoryOptionUpdates.Any() || PerformanceMeasureExpectedUpdates.Any() || PerformanceMeasureFixedTargets.Any() || PerformanceMeasureImages.Any() || PerformanceMeasureNotes.Any() || PerformanceMeasureReportingPeriodTargets.Any() || PerformanceMeasureSubcategories.Any() || TaxonomyLeafPerformanceMeasures.Any();
+            return ClassificationPerformanceMeasures.Any() || GeospatialAreaPerformanceMeasureFixedTargets.Any() || GeospatialAreaPerformanceMeasureNoTargets.Any() || GeospatialAreaPerformanceMeasureReportingPeriodTargets.Any() || MatchmakerOrganizationPerformanceMeasures.Any() || PerformanceMeasureActuals.Any() || PerformanceMeasureActualSubcategoryOptions.Any() || PerformanceMeasureActualSubcategoryOptionUpdates.Any() || PerformanceMeasureActualUpdates.Any() || PerformanceMeasureExpecteds.Any() || PerformanceMeasureExpectedSubcategoryOptions.Any() || PerformanceMeasureExpectedSubcategoryOptionUpdates.Any() || PerformanceMeasureExpectedUpdates.Any() || PerformanceMeasureFixedTargets.Any() || PerformanceMeasureImages.Any() || PerformanceMeasureNotes.Any() || PerformanceMeasureReportingPeriodTargets.Any() || PerformanceMeasureSubcategories.Any() || SubprojectPerformanceMeasureActuals.Any() || SubprojectPerformanceMeasureActualSubcategoryOptions.Any() || SubprojectPerformanceMeasureExpecteds.Any() || SubprojectPerformanceMeasureExpectedSubcategoryOptions.Any() || TaxonomyLeafPerformanceMeasures.Any();
         }
 
         /// <summary>
@@ -217,6 +221,26 @@ namespace ProjectFirmaModels.Models
                 dependentObjects.Add(typeof(PerformanceMeasureSubcategory).Name);
             }
 
+            if(SubprojectPerformanceMeasureActuals.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureActual).Name);
+            }
+
+            if(SubprojectPerformanceMeasureActualSubcategoryOptions.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureActualSubcategoryOption).Name);
+            }
+
+            if(SubprojectPerformanceMeasureExpecteds.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureExpected).Name);
+            }
+
+            if(SubprojectPerformanceMeasureExpectedSubcategoryOptions.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureExpectedSubcategoryOption).Name);
+            }
+
             if(TaxonomyLeafPerformanceMeasures.Any())
             {
                 dependentObjects.Add(typeof(TaxonomyLeafPerformanceMeasure).Name);
@@ -227,7 +251,7 @@ namespace ProjectFirmaModels.Models
         /// <summary>
         /// Dependent type names of this entity
         /// </summary>
-        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(PerformanceMeasure).Name, typeof(ClassificationPerformanceMeasure).Name, typeof(GeospatialAreaPerformanceMeasureFixedTarget).Name, typeof(GeospatialAreaPerformanceMeasureNoTarget).Name, typeof(GeospatialAreaPerformanceMeasureReportingPeriodTarget).Name, typeof(MatchmakerOrganizationPerformanceMeasure).Name, typeof(PerformanceMeasureActual).Name, typeof(PerformanceMeasureActualSubcategoryOption).Name, typeof(PerformanceMeasureActualSubcategoryOptionUpdate).Name, typeof(PerformanceMeasureActualUpdate).Name, typeof(PerformanceMeasureExpected).Name, typeof(PerformanceMeasureExpectedSubcategoryOption).Name, typeof(PerformanceMeasureExpectedSubcategoryOptionUpdate).Name, typeof(PerformanceMeasureExpectedUpdate).Name, typeof(PerformanceMeasureFixedTarget).Name, typeof(PerformanceMeasureImage).Name, typeof(PerformanceMeasureNote).Name, typeof(PerformanceMeasureReportingPeriodTarget).Name, typeof(PerformanceMeasureSubcategory).Name, typeof(TaxonomyLeafPerformanceMeasure).Name};
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(PerformanceMeasure).Name, typeof(ClassificationPerformanceMeasure).Name, typeof(GeospatialAreaPerformanceMeasureFixedTarget).Name, typeof(GeospatialAreaPerformanceMeasureNoTarget).Name, typeof(GeospatialAreaPerformanceMeasureReportingPeriodTarget).Name, typeof(MatchmakerOrganizationPerformanceMeasure).Name, typeof(PerformanceMeasureActual).Name, typeof(PerformanceMeasureActualSubcategoryOption).Name, typeof(PerformanceMeasureActualSubcategoryOptionUpdate).Name, typeof(PerformanceMeasureActualUpdate).Name, typeof(PerformanceMeasureExpected).Name, typeof(PerformanceMeasureExpectedSubcategoryOption).Name, typeof(PerformanceMeasureExpectedSubcategoryOptionUpdate).Name, typeof(PerformanceMeasureExpectedUpdate).Name, typeof(PerformanceMeasureFixedTarget).Name, typeof(PerformanceMeasureImage).Name, typeof(PerformanceMeasureNote).Name, typeof(PerformanceMeasureReportingPeriodTarget).Name, typeof(PerformanceMeasureSubcategory).Name, typeof(SubprojectPerformanceMeasureActual).Name, typeof(SubprojectPerformanceMeasureActualSubcategoryOption).Name, typeof(SubprojectPerformanceMeasureExpected).Name, typeof(SubprojectPerformanceMeasureExpectedSubcategoryOption).Name, typeof(TaxonomyLeafPerformanceMeasure).Name};
 
 
         /// <summary>
@@ -342,6 +366,26 @@ namespace ProjectFirmaModels.Models
                 x.DeleteFull(dbContext);
             }
 
+            foreach(var x in SubprojectPerformanceMeasureActuals.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
+
+            foreach(var x in SubprojectPerformanceMeasureActualSubcategoryOptions.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
+
+            foreach(var x in SubprojectPerformanceMeasureExpecteds.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
+
+            foreach(var x in SubprojectPerformanceMeasureExpectedSubcategoryOptions.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
+
             foreach(var x in TaxonomyLeafPerformanceMeasures.ToList())
             {
                 x.DeleteFull(dbContext);
@@ -412,6 +456,10 @@ namespace ProjectFirmaModels.Models
         public virtual ICollection<PerformanceMeasureNote> PerformanceMeasureNotes { get; set; }
         public virtual ICollection<PerformanceMeasureReportingPeriodTarget> PerformanceMeasureReportingPeriodTargets { get; set; }
         public virtual ICollection<PerformanceMeasureSubcategory> PerformanceMeasureSubcategories { get; set; }
+        public virtual ICollection<SubprojectPerformanceMeasureActual> SubprojectPerformanceMeasureActuals { get; set; }
+        public virtual ICollection<SubprojectPerformanceMeasureActualSubcategoryOption> SubprojectPerformanceMeasureActualSubcategoryOptions { get; set; }
+        public virtual ICollection<SubprojectPerformanceMeasureExpected> SubprojectPerformanceMeasureExpecteds { get; set; }
+        public virtual ICollection<SubprojectPerformanceMeasureExpectedSubcategoryOption> SubprojectPerformanceMeasureExpectedSubcategoryOptions { get; set; }
         public virtual ICollection<TaxonomyLeafPerformanceMeasure> TaxonomyLeafPerformanceMeasures { get; set; }
         public Tenant Tenant { get { return Tenant.AllLookupDictionary[TenantID]; } }
         public MeasurementUnitType MeasurementUnitType { get { return MeasurementUnitType.AllLookupDictionary[MeasurementUnitTypeID]; } }

--- a/Source/ProjectFirmaModels/Models/Generated/PerformanceMeasureActual.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/PerformanceMeasureActual.Binding.cs
@@ -26,6 +26,7 @@ namespace ProjectFirmaModels.Models
         protected PerformanceMeasureActual()
         {
             this.PerformanceMeasureActualSubcategoryOptions = new HashSet<PerformanceMeasureActualSubcategoryOption>();
+            this.SubprojectPerformanceMeasureActualSubcategoryOptionsWhereYouAreTheSubprojectPerformanceMeasureActual = new HashSet<SubprojectPerformanceMeasureActualSubcategoryOption>();
         }
 
         /// <summary>
@@ -87,7 +88,7 @@ namespace ProjectFirmaModels.Models
         /// <returns></returns>
         public bool HasDependentObjects()
         {
-            return PerformanceMeasureActualSubcategoryOptions.Any();
+            return PerformanceMeasureActualSubcategoryOptions.Any() || SubprojectPerformanceMeasureActualSubcategoryOptionsWhereYouAreTheSubprojectPerformanceMeasureActual.Any();
         }
 
         /// <summary>
@@ -101,13 +102,18 @@ namespace ProjectFirmaModels.Models
             {
                 dependentObjects.Add(typeof(PerformanceMeasureActualSubcategoryOption).Name);
             }
+
+            if(SubprojectPerformanceMeasureActualSubcategoryOptionsWhereYouAreTheSubprojectPerformanceMeasureActual.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureActualSubcategoryOption).Name);
+            }
             return dependentObjects.Distinct().ToList();
         }
 
         /// <summary>
         /// Dependent type names of this entity
         /// </summary>
-        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(PerformanceMeasureActual).Name, typeof(PerformanceMeasureActualSubcategoryOption).Name};
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(PerformanceMeasureActual).Name, typeof(PerformanceMeasureActualSubcategoryOption).Name, typeof(SubprojectPerformanceMeasureActualSubcategoryOption).Name};
 
 
         /// <summary>
@@ -136,6 +142,11 @@ namespace ProjectFirmaModels.Models
             {
                 x.DeleteFull(dbContext);
             }
+
+            foreach(var x in SubprojectPerformanceMeasureActualSubcategoryOptionsWhereYouAreTheSubprojectPerformanceMeasureActual.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
         }
 
         [Key]
@@ -149,6 +160,7 @@ namespace ProjectFirmaModels.Models
         public int PrimaryKey { get { return PerformanceMeasureActualID; } set { PerformanceMeasureActualID = value; } }
 
         public virtual ICollection<PerformanceMeasureActualSubcategoryOption> PerformanceMeasureActualSubcategoryOptions { get; set; }
+        public virtual ICollection<SubprojectPerformanceMeasureActualSubcategoryOption> SubprojectPerformanceMeasureActualSubcategoryOptionsWhereYouAreTheSubprojectPerformanceMeasureActual { get; set; }
         public Tenant Tenant { get { return Tenant.AllLookupDictionary[TenantID]; } }
         public virtual Project Project { get; set; }
         public virtual PerformanceMeasure PerformanceMeasure { get; set; }

--- a/Source/ProjectFirmaModels/Models/Generated/PerformanceMeasureReportingPeriod.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/PerformanceMeasureReportingPeriod.Binding.cs
@@ -29,6 +29,7 @@ namespace ProjectFirmaModels.Models
             this.PerformanceMeasureActuals = new HashSet<PerformanceMeasureActual>();
             this.PerformanceMeasureActualUpdates = new HashSet<PerformanceMeasureActualUpdate>();
             this.PerformanceMeasureReportingPeriodTargets = new HashSet<PerformanceMeasureReportingPeriodTarget>();
+            this.SubprojectPerformanceMeasureActuals = new HashSet<SubprojectPerformanceMeasureActual>();
         }
 
         /// <summary>
@@ -68,7 +69,7 @@ namespace ProjectFirmaModels.Models
         /// <returns></returns>
         public bool HasDependentObjects()
         {
-            return GeospatialAreaPerformanceMeasureReportingPeriodTargets.Any() || PerformanceMeasureActuals.Any() || PerformanceMeasureActualUpdates.Any() || PerformanceMeasureReportingPeriodTargets.Any();
+            return GeospatialAreaPerformanceMeasureReportingPeriodTargets.Any() || PerformanceMeasureActuals.Any() || PerformanceMeasureActualUpdates.Any() || PerformanceMeasureReportingPeriodTargets.Any() || SubprojectPerformanceMeasureActuals.Any();
         }
 
         /// <summary>
@@ -97,13 +98,18 @@ namespace ProjectFirmaModels.Models
             {
                 dependentObjects.Add(typeof(PerformanceMeasureReportingPeriodTarget).Name);
             }
+
+            if(SubprojectPerformanceMeasureActuals.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureActual).Name);
+            }
             return dependentObjects.Distinct().ToList();
         }
 
         /// <summary>
         /// Dependent type names of this entity
         /// </summary>
-        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(PerformanceMeasureReportingPeriod).Name, typeof(GeospatialAreaPerformanceMeasureReportingPeriodTarget).Name, typeof(PerformanceMeasureActual).Name, typeof(PerformanceMeasureActualUpdate).Name, typeof(PerformanceMeasureReportingPeriodTarget).Name};
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(PerformanceMeasureReportingPeriod).Name, typeof(GeospatialAreaPerformanceMeasureReportingPeriodTarget).Name, typeof(PerformanceMeasureActual).Name, typeof(PerformanceMeasureActualUpdate).Name, typeof(PerformanceMeasureReportingPeriodTarget).Name, typeof(SubprojectPerformanceMeasureActual).Name};
 
 
         /// <summary>
@@ -147,6 +153,11 @@ namespace ProjectFirmaModels.Models
             {
                 x.DeleteFull(dbContext);
             }
+
+            foreach(var x in SubprojectPerformanceMeasureActuals.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
         }
 
         [Key]
@@ -161,6 +172,7 @@ namespace ProjectFirmaModels.Models
         public virtual ICollection<PerformanceMeasureActual> PerformanceMeasureActuals { get; set; }
         public virtual ICollection<PerformanceMeasureActualUpdate> PerformanceMeasureActualUpdates { get; set; }
         public virtual ICollection<PerformanceMeasureReportingPeriodTarget> PerformanceMeasureReportingPeriodTargets { get; set; }
+        public virtual ICollection<SubprojectPerformanceMeasureActual> SubprojectPerformanceMeasureActuals { get; set; }
         public Tenant Tenant { get { return Tenant.AllLookupDictionary[TenantID]; } }
 
         public static class FieldLengths

--- a/Source/ProjectFirmaModels/Models/Generated/PerformanceMeasureSubcategory.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/PerformanceMeasureSubcategory.Binding.cs
@@ -30,6 +30,8 @@ namespace ProjectFirmaModels.Models
             this.PerformanceMeasureExpectedSubcategoryOptions = new HashSet<PerformanceMeasureExpectedSubcategoryOption>();
             this.PerformanceMeasureExpectedSubcategoryOptionUpdates = new HashSet<PerformanceMeasureExpectedSubcategoryOptionUpdate>();
             this.PerformanceMeasureSubcategoryOptions = new HashSet<PerformanceMeasureSubcategoryOption>();
+            this.SubprojectPerformanceMeasureActualSubcategoryOptions = new HashSet<SubprojectPerformanceMeasureActualSubcategoryOption>();
+            this.SubprojectPerformanceMeasureExpectedSubcategoryOptions = new HashSet<SubprojectPerformanceMeasureExpectedSubcategoryOption>();
         }
 
         /// <summary>
@@ -87,7 +89,7 @@ namespace ProjectFirmaModels.Models
         /// <returns></returns>
         public bool HasDependentObjects()
         {
-            return PerformanceMeasureActualSubcategoryOptions.Any() || PerformanceMeasureActualSubcategoryOptionUpdates.Any() || PerformanceMeasureExpectedSubcategoryOptions.Any() || PerformanceMeasureExpectedSubcategoryOptionUpdates.Any() || PerformanceMeasureSubcategoryOptions.Any();
+            return PerformanceMeasureActualSubcategoryOptions.Any() || PerformanceMeasureActualSubcategoryOptionUpdates.Any() || PerformanceMeasureExpectedSubcategoryOptions.Any() || PerformanceMeasureExpectedSubcategoryOptionUpdates.Any() || PerformanceMeasureSubcategoryOptions.Any() || SubprojectPerformanceMeasureActualSubcategoryOptions.Any() || SubprojectPerformanceMeasureExpectedSubcategoryOptions.Any();
         }
 
         /// <summary>
@@ -121,13 +123,23 @@ namespace ProjectFirmaModels.Models
             {
                 dependentObjects.Add(typeof(PerformanceMeasureSubcategoryOption).Name);
             }
+
+            if(SubprojectPerformanceMeasureActualSubcategoryOptions.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureActualSubcategoryOption).Name);
+            }
+
+            if(SubprojectPerformanceMeasureExpectedSubcategoryOptions.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureExpectedSubcategoryOption).Name);
+            }
             return dependentObjects.Distinct().ToList();
         }
 
         /// <summary>
         /// Dependent type names of this entity
         /// </summary>
-        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(PerformanceMeasureSubcategory).Name, typeof(PerformanceMeasureActualSubcategoryOption).Name, typeof(PerformanceMeasureActualSubcategoryOptionUpdate).Name, typeof(PerformanceMeasureExpectedSubcategoryOption).Name, typeof(PerformanceMeasureExpectedSubcategoryOptionUpdate).Name, typeof(PerformanceMeasureSubcategoryOption).Name};
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(PerformanceMeasureSubcategory).Name, typeof(PerformanceMeasureActualSubcategoryOption).Name, typeof(PerformanceMeasureActualSubcategoryOptionUpdate).Name, typeof(PerformanceMeasureExpectedSubcategoryOption).Name, typeof(PerformanceMeasureExpectedSubcategoryOptionUpdate).Name, typeof(PerformanceMeasureSubcategoryOption).Name, typeof(SubprojectPerformanceMeasureActualSubcategoryOption).Name, typeof(SubprojectPerformanceMeasureExpectedSubcategoryOption).Name};
 
 
         /// <summary>
@@ -176,6 +188,16 @@ namespace ProjectFirmaModels.Models
             {
                 x.DeleteFull(dbContext);
             }
+
+            foreach(var x in SubprojectPerformanceMeasureActualSubcategoryOptions.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
+
+            foreach(var x in SubprojectPerformanceMeasureExpectedSubcategoryOptions.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
         }
 
         [Key]
@@ -197,6 +219,8 @@ namespace ProjectFirmaModels.Models
         public virtual ICollection<PerformanceMeasureExpectedSubcategoryOption> PerformanceMeasureExpectedSubcategoryOptions { get; set; }
         public virtual ICollection<PerformanceMeasureExpectedSubcategoryOptionUpdate> PerformanceMeasureExpectedSubcategoryOptionUpdates { get; set; }
         public virtual ICollection<PerformanceMeasureSubcategoryOption> PerformanceMeasureSubcategoryOptions { get; set; }
+        public virtual ICollection<SubprojectPerformanceMeasureActualSubcategoryOption> SubprojectPerformanceMeasureActualSubcategoryOptions { get; set; }
+        public virtual ICollection<SubprojectPerformanceMeasureExpectedSubcategoryOption> SubprojectPerformanceMeasureExpectedSubcategoryOptions { get; set; }
         public Tenant Tenant { get { return Tenant.AllLookupDictionary[TenantID]; } }
         public virtual PerformanceMeasure PerformanceMeasure { get; set; }
         public GoogleChartType CumulativeGoogleChartType { get { return CumulativeGoogleChartTypeID.HasValue ? GoogleChartType.AllLookupDictionary[CumulativeGoogleChartTypeID.Value] : null; } }

--- a/Source/ProjectFirmaModels/Models/Generated/PerformanceMeasureSubcategoryOption.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/PerformanceMeasureSubcategoryOption.Binding.cs
@@ -29,6 +29,8 @@ namespace ProjectFirmaModels.Models
             this.PerformanceMeasureActualSubcategoryOptionUpdates = new HashSet<PerformanceMeasureActualSubcategoryOptionUpdate>();
             this.PerformanceMeasureExpectedSubcategoryOptions = new HashSet<PerformanceMeasureExpectedSubcategoryOption>();
             this.PerformanceMeasureExpectedSubcategoryOptionUpdates = new HashSet<PerformanceMeasureExpectedSubcategoryOptionUpdate>();
+            this.SubprojectPerformanceMeasureActualSubcategoryOptions = new HashSet<SubprojectPerformanceMeasureActualSubcategoryOption>();
+            this.SubprojectPerformanceMeasureExpectedSubcategoryOptions = new HashSet<SubprojectPerformanceMeasureExpectedSubcategoryOption>();
         }
 
         /// <summary>
@@ -84,7 +86,7 @@ namespace ProjectFirmaModels.Models
         /// <returns></returns>
         public bool HasDependentObjects()
         {
-            return PerformanceMeasureActualSubcategoryOptions.Any() || PerformanceMeasureActualSubcategoryOptionUpdates.Any() || PerformanceMeasureExpectedSubcategoryOptions.Any() || PerformanceMeasureExpectedSubcategoryOptionUpdates.Any();
+            return PerformanceMeasureActualSubcategoryOptions.Any() || PerformanceMeasureActualSubcategoryOptionUpdates.Any() || PerformanceMeasureExpectedSubcategoryOptions.Any() || PerformanceMeasureExpectedSubcategoryOptionUpdates.Any() || SubprojectPerformanceMeasureActualSubcategoryOptions.Any() || SubprojectPerformanceMeasureExpectedSubcategoryOptions.Any();
         }
 
         /// <summary>
@@ -113,13 +115,23 @@ namespace ProjectFirmaModels.Models
             {
                 dependentObjects.Add(typeof(PerformanceMeasureExpectedSubcategoryOptionUpdate).Name);
             }
+
+            if(SubprojectPerformanceMeasureActualSubcategoryOptions.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureActualSubcategoryOption).Name);
+            }
+
+            if(SubprojectPerformanceMeasureExpectedSubcategoryOptions.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureExpectedSubcategoryOption).Name);
+            }
             return dependentObjects.Distinct().ToList();
         }
 
         /// <summary>
         /// Dependent type names of this entity
         /// </summary>
-        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(PerformanceMeasureSubcategoryOption).Name, typeof(PerformanceMeasureActualSubcategoryOption).Name, typeof(PerformanceMeasureActualSubcategoryOptionUpdate).Name, typeof(PerformanceMeasureExpectedSubcategoryOption).Name, typeof(PerformanceMeasureExpectedSubcategoryOptionUpdate).Name};
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(PerformanceMeasureSubcategoryOption).Name, typeof(PerformanceMeasureActualSubcategoryOption).Name, typeof(PerformanceMeasureActualSubcategoryOptionUpdate).Name, typeof(PerformanceMeasureExpectedSubcategoryOption).Name, typeof(PerformanceMeasureExpectedSubcategoryOptionUpdate).Name, typeof(SubprojectPerformanceMeasureActualSubcategoryOption).Name, typeof(SubprojectPerformanceMeasureExpectedSubcategoryOption).Name};
 
 
         /// <summary>
@@ -163,6 +175,16 @@ namespace ProjectFirmaModels.Models
             {
                 x.DeleteFull(dbContext);
             }
+
+            foreach(var x in SubprojectPerformanceMeasureActualSubcategoryOptions.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
+
+            foreach(var x in SubprojectPerformanceMeasureExpectedSubcategoryOptions.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
         }
 
         [Key]
@@ -179,6 +201,8 @@ namespace ProjectFirmaModels.Models
         public virtual ICollection<PerformanceMeasureActualSubcategoryOptionUpdate> PerformanceMeasureActualSubcategoryOptionUpdates { get; set; }
         public virtual ICollection<PerformanceMeasureExpectedSubcategoryOption> PerformanceMeasureExpectedSubcategoryOptions { get; set; }
         public virtual ICollection<PerformanceMeasureExpectedSubcategoryOptionUpdate> PerformanceMeasureExpectedSubcategoryOptionUpdates { get; set; }
+        public virtual ICollection<SubprojectPerformanceMeasureActualSubcategoryOption> SubprojectPerformanceMeasureActualSubcategoryOptions { get; set; }
+        public virtual ICollection<SubprojectPerformanceMeasureExpectedSubcategoryOption> SubprojectPerformanceMeasureExpectedSubcategoryOptions { get; set; }
         public Tenant Tenant { get { return Tenant.AllLookupDictionary[TenantID]; } }
         public virtual PerformanceMeasureSubcategory PerformanceMeasureSubcategory { get; set; }
 

--- a/Source/ProjectFirmaModels/Models/Generated/Project.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/Project.Binding.cs
@@ -52,6 +52,7 @@ namespace ProjectFirmaModels.Models
             this.ProjectTags = new HashSet<ProjectTag>();
             this.ProjectUpdateBatches = new HashSet<ProjectUpdateBatch>();
             this.SecondaryProjectTaxonomyLeafs = new HashSet<SecondaryProjectTaxonomyLeaf>();
+            this.Subprojects = new HashSet<Subproject>();
             this.TechnicalAssistanceRequests = new HashSet<TechnicalAssistanceRequest>();
             this.CostAuthorityProjects = new HashSet<CostAuthorityProject>();
             this.ProjectFundingSourceBudgets = new HashSet<ProjectFundingSourceBudget>();
@@ -162,7 +163,7 @@ namespace ProjectFirmaModels.Models
         /// <returns></returns>
         public bool HasDependentObjects()
         {
-            return ActionItems.Any() || NotificationProjects.Any() || PerformanceMeasureActuals.Any() || PerformanceMeasureExpecteds.Any() || ProjectAssessmentQuestions.Any() || ProjectAttachments.Any() || ProjectClassifications.Any() || ProjectContacts.Any() || ProjectCustomAttributes.Any() || ProjectEvaluations.Any() || ProjectExemptReportingYears.Any() || ProjectExternalLinks.Any() || ProjectFundingSourceExpenditures.Any() || ProjectGeospatialAreas.Any() || ProjectGeospatialAreaTypeNotes.Any() || ProjectImages.Any() || ProjectInternalNotes.Any() || ProjectLocations.Any() || ProjectLocationStagings.Any() || ProjectNoFundingSourceIdentifieds.Any() || ProjectNotes.Any() || ProjectOrganizations.Any() || ProjectProjectStatuses.Any() || ProjectRelevantCostTypes.Any() || ProjectTags.Any() || ProjectUpdateBatches.Any() || SecondaryProjectTaxonomyLeafs.Any() || TechnicalAssistanceRequests.Any() || CostAuthorityProjects.Any() || ProjectFundingSourceBudgets.Any();
+            return ActionItems.Any() || NotificationProjects.Any() || PerformanceMeasureActuals.Any() || PerformanceMeasureExpecteds.Any() || ProjectAssessmentQuestions.Any() || ProjectAttachments.Any() || ProjectClassifications.Any() || ProjectContacts.Any() || ProjectCustomAttributes.Any() || ProjectEvaluations.Any() || ProjectExemptReportingYears.Any() || ProjectExternalLinks.Any() || ProjectFundingSourceExpenditures.Any() || ProjectGeospatialAreas.Any() || ProjectGeospatialAreaTypeNotes.Any() || ProjectImages.Any() || ProjectInternalNotes.Any() || ProjectLocations.Any() || ProjectLocationStagings.Any() || ProjectNoFundingSourceIdentifieds.Any() || ProjectNotes.Any() || ProjectOrganizations.Any() || ProjectProjectStatuses.Any() || ProjectRelevantCostTypes.Any() || ProjectTags.Any() || ProjectUpdateBatches.Any() || SecondaryProjectTaxonomyLeafs.Any() || Subprojects.Any() || TechnicalAssistanceRequests.Any() || CostAuthorityProjects.Any() || ProjectFundingSourceBudgets.Any();
         }
 
         /// <summary>
@@ -307,6 +308,11 @@ namespace ProjectFirmaModels.Models
                 dependentObjects.Add(typeof(SecondaryProjectTaxonomyLeaf).Name);
             }
 
+            if(Subprojects.Any())
+            {
+                dependentObjects.Add(typeof(Subproject).Name);
+            }
+
             if(TechnicalAssistanceRequests.Any())
             {
                 dependentObjects.Add(typeof(TechnicalAssistanceRequest).Name);
@@ -327,7 +333,7 @@ namespace ProjectFirmaModels.Models
         /// <summary>
         /// Dependent type names of this entity
         /// </summary>
-        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(Project).Name, typeof(ActionItem).Name, typeof(NotificationProject).Name, typeof(PerformanceMeasureActual).Name, typeof(PerformanceMeasureExpected).Name, typeof(ProjectAssessmentQuestion).Name, typeof(ProjectAttachment).Name, typeof(ProjectClassification).Name, typeof(ProjectContact).Name, typeof(ProjectCustomAttribute).Name, typeof(ProjectEvaluation).Name, typeof(ProjectExemptReportingYear).Name, typeof(ProjectExternalLink).Name, typeof(ProjectFundingSourceExpenditure).Name, typeof(ProjectGeospatialArea).Name, typeof(ProjectGeospatialAreaTypeNote).Name, typeof(ProjectImage).Name, typeof(ProjectInternalNote).Name, typeof(ProjectLocation).Name, typeof(ProjectLocationStaging).Name, typeof(ProjectNoFundingSourceIdentified).Name, typeof(ProjectNote).Name, typeof(ProjectOrganization).Name, typeof(ProjectProjectStatus).Name, typeof(ProjectRelevantCostType).Name, typeof(ProjectTag).Name, typeof(ProjectUpdateBatch).Name, typeof(SecondaryProjectTaxonomyLeaf).Name, typeof(TechnicalAssistanceRequest).Name, typeof(CostAuthorityProject).Name, typeof(ProjectFundingSourceBudget).Name};
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(Project).Name, typeof(ActionItem).Name, typeof(NotificationProject).Name, typeof(PerformanceMeasureActual).Name, typeof(PerformanceMeasureExpected).Name, typeof(ProjectAssessmentQuestion).Name, typeof(ProjectAttachment).Name, typeof(ProjectClassification).Name, typeof(ProjectContact).Name, typeof(ProjectCustomAttribute).Name, typeof(ProjectEvaluation).Name, typeof(ProjectExemptReportingYear).Name, typeof(ProjectExternalLink).Name, typeof(ProjectFundingSourceExpenditure).Name, typeof(ProjectGeospatialArea).Name, typeof(ProjectGeospatialAreaTypeNote).Name, typeof(ProjectImage).Name, typeof(ProjectInternalNote).Name, typeof(ProjectLocation).Name, typeof(ProjectLocationStaging).Name, typeof(ProjectNoFundingSourceIdentified).Name, typeof(ProjectNote).Name, typeof(ProjectOrganization).Name, typeof(ProjectProjectStatus).Name, typeof(ProjectRelevantCostType).Name, typeof(ProjectTag).Name, typeof(ProjectUpdateBatch).Name, typeof(SecondaryProjectTaxonomyLeaf).Name, typeof(Subproject).Name, typeof(TechnicalAssistanceRequest).Name, typeof(CostAuthorityProject).Name, typeof(ProjectFundingSourceBudget).Name};
 
 
         /// <summary>
@@ -487,6 +493,11 @@ namespace ProjectFirmaModels.Models
                 x.DeleteFull(dbContext);
             }
 
+            foreach(var x in Subprojects.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
+
             foreach(var x in TechnicalAssistanceRequests.ToList())
             {
                 x.DeleteFull(dbContext);
@@ -582,6 +593,7 @@ namespace ProjectFirmaModels.Models
         public virtual ICollection<ProjectTag> ProjectTags { get; set; }
         public virtual ICollection<ProjectUpdateBatch> ProjectUpdateBatches { get; set; }
         public virtual ICollection<SecondaryProjectTaxonomyLeaf> SecondaryProjectTaxonomyLeafs { get; set; }
+        public virtual ICollection<Subproject> Subprojects { get; set; }
         public virtual ICollection<TechnicalAssistanceRequest> TechnicalAssistanceRequests { get; set; }
         public virtual ICollection<CostAuthorityProject> CostAuthorityProjects { get; set; }
         public virtual ICollection<ProjectFundingSourceBudget> ProjectFundingSourceBudgets { get; set; }

--- a/Source/ProjectFirmaModels/Models/Generated/Subproject.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/Subproject.Binding.cs
@@ -1,0 +1,173 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[Subproject]
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+using System.Data.Entity.Spatial;
+using System.Linq;
+using System.Web;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    // Table [dbo].[Subproject] is multi-tenant, so is attributed as IHaveATenantID
+    [Table("[dbo].[Subproject]")]
+    public partial class Subproject : IHavePrimaryKey, IHaveATenantID
+    {
+        /// <summary>
+        /// Default Constructor; only used by EF
+        /// </summary>
+        protected Subproject()
+        {
+            this.SubprojectPerformanceMeasureActuals = new HashSet<SubprojectPerformanceMeasureActual>();
+            this.SubprojectPerformanceMeasureExpecteds = new HashSet<SubprojectPerformanceMeasureExpected>();
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MaximalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public Subproject(int subprojectID, int projectID, int projectStageID, int? implementationStartYear, int? completeionYear, string notes) : this()
+        {
+            this.SubprojectID = subprojectID;
+            this.ProjectID = projectID;
+            this.ProjectStageID = projectStageID;
+            this.ImplementationStartYear = implementationStartYear;
+            this.CompleteionYear = completeionYear;
+            this.Notes = notes;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public Subproject(int projectID, int projectStageID) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.SubprojectID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            
+            this.ProjectID = projectID;
+            this.ProjectStageID = projectStageID;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields, using objects whenever possible
+        /// </summary>
+        public Subproject(Project project, ProjectStage projectStage) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.SubprojectID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            this.ProjectID = project.ProjectID;
+            this.Project = project;
+            project.Subprojects.Add(this);
+            this.ProjectStageID = projectStage.ProjectStageID;
+        }
+
+        /// <summary>
+        /// Creates a "blank" object of this type and populates primitives with defaults
+        /// </summary>
+        public static Subproject CreateNewBlank(Project project, ProjectStage projectStage)
+        {
+            return new Subproject(project, projectStage);
+        }
+
+        /// <summary>
+        /// Does this object have any dependent objects? (If it does have dependent objects, these would need to be deleted before this object could be deleted.)
+        /// </summary>
+        /// <returns></returns>
+        public bool HasDependentObjects()
+        {
+            return SubprojectPerformanceMeasureActuals.Any() || SubprojectPerformanceMeasureExpecteds.Any();
+        }
+
+        /// <summary>
+        /// Active Dependent type names of this object
+        /// </summary>
+        public List<string> DependentObjectNames() 
+        {
+            var dependentObjects = new List<string>();
+            
+            if(SubprojectPerformanceMeasureActuals.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureActual).Name);
+            }
+
+            if(SubprojectPerformanceMeasureExpecteds.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureExpected).Name);
+            }
+            return dependentObjects.Distinct().ToList();
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(Subproject).Name, typeof(SubprojectPerformanceMeasureActual).Name, typeof(SubprojectPerformanceMeasureExpected).Name};
+
+
+        /// <summary>
+        /// Delete just the entity 
+        /// </summary>
+        public void Delete(DatabaseEntities dbContext)
+        {
+            dbContext.AllSubprojects.Remove(this);
+        }
+        
+        /// <summary>
+        /// Delete entity plus all children
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            DeleteChildren(dbContext);
+            Delete(dbContext);
+        }
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteChildren(DatabaseEntities dbContext)
+        {
+
+            foreach(var x in SubprojectPerformanceMeasureActuals.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
+
+            foreach(var x in SubprojectPerformanceMeasureExpecteds.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
+        }
+
+        [Key]
+        public int SubprojectID { get; set; }
+        public int TenantID { get; set; }
+        public int ProjectID { get; set; }
+        public int ProjectStageID { get; set; }
+        public int? ImplementationStartYear { get; set; }
+        public int? CompleteionYear { get; set; }
+        public string Notes { get; set; }
+        [NotMapped]
+        public HtmlString NotesHtmlString
+        { 
+            get { return Notes == null ? null : new HtmlString(Notes); }
+            set { Notes = value?.ToString(); }
+        }
+        [NotMapped]
+        public int PrimaryKey { get { return SubprojectID; } set { SubprojectID = value; } }
+
+        public virtual ICollection<SubprojectPerformanceMeasureActual> SubprojectPerformanceMeasureActuals { get; set; }
+        public virtual ICollection<SubprojectPerformanceMeasureExpected> SubprojectPerformanceMeasureExpecteds { get; set; }
+        public Tenant Tenant { get { return Tenant.AllLookupDictionary[TenantID]; } }
+        public virtual Project Project { get; set; }
+        public ProjectStage ProjectStage { get { return ProjectStage.AllLookupDictionary[ProjectStageID]; } }
+
+        public static class FieldLengths
+        {
+
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/Subproject.DatabaseContextExtensions.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/Subproject.DatabaseContextExtensions.cs
@@ -1,0 +1,24 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[Subproject]
+using System.Collections.Generic;
+using System.Linq;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public static partial class DatabaseContextExtensions
+    {
+        public static Subproject GetSubproject(this IQueryable<Subproject> subprojects, int subprojectID)
+        {
+            var subproject = subprojects.SingleOrDefault(x => x.SubprojectID == subprojectID);
+            Check.RequireNotNullThrowNotFound(subproject, "Subproject", subprojectID);
+            return subproject;
+        }
+
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectConfiguration.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectConfiguration.Binding.cs
@@ -1,0 +1,30 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[Subproject]
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity.ModelConfiguration;
+
+namespace ProjectFirmaModels.Models
+{
+    public class SubprojectConfiguration : EntityTypeConfiguration<Subproject>
+    {
+        public SubprojectConfiguration() : this("dbo"){}
+
+        public SubprojectConfiguration(string schema)
+        {
+            ToTable("Subproject", schema);
+            HasKey(x => x.SubprojectID);
+            Property(x => x.SubprojectID).HasColumnName(@"SubprojectID").HasColumnType("int").IsRequired().HasDatabaseGeneratedOption(DatabaseGeneratedOption.Identity);
+            Property(x => x.TenantID).HasColumnName(@"TenantID").HasColumnType("int").IsRequired();
+            Property(x => x.ProjectID).HasColumnName(@"ProjectID").HasColumnType("int").IsRequired();
+            Property(x => x.ProjectStageID).HasColumnName(@"ProjectStageID").HasColumnType("int").IsRequired();
+            Property(x => x.ImplementationStartYear).HasColumnName(@"ImplementationStartYear").HasColumnType("int").IsOptional();
+            Property(x => x.CompleteionYear).HasColumnName(@"CompleteionYear").HasColumnType("int").IsOptional();
+            Property(x => x.Notes).HasColumnName(@"Notes").HasColumnType("varchar").IsOptional();
+
+            // Foreign keys
+            HasRequired(a => a.Project).WithMany(b => b.Subprojects).HasForeignKey(c => c.ProjectID).WillCascadeOnDelete(false); // FK_Subproject_Project_ProjectID
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActual.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActual.Binding.cs
@@ -1,0 +1,146 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureActual]
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+using System.Data.Entity.Spatial;
+using System.Linq;
+using System.Web;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    // Table [dbo].[SubprojectPerformanceMeasureActual] is multi-tenant, so is attributed as IHaveATenantID
+    [Table("[dbo].[SubprojectPerformanceMeasureActual]")]
+    public partial class SubprojectPerformanceMeasureActual : IHavePrimaryKey, IHaveATenantID
+    {
+        /// <summary>
+        /// Default Constructor; only used by EF
+        /// </summary>
+        protected SubprojectPerformanceMeasureActual()
+        {
+
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MaximalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public SubprojectPerformanceMeasureActual(int subprojectPerformanceMeasureActualID, int subprojectID, int performanceMeasureID, double actualValue, int performanceMeasureReportingPeriodID) : this()
+        {
+            this.SubprojectPerformanceMeasureActualID = subprojectPerformanceMeasureActualID;
+            this.SubprojectID = subprojectID;
+            this.PerformanceMeasureID = performanceMeasureID;
+            this.ActualValue = actualValue;
+            this.PerformanceMeasureReportingPeriodID = performanceMeasureReportingPeriodID;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public SubprojectPerformanceMeasureActual(int subprojectID, int performanceMeasureID, double actualValue, int performanceMeasureReportingPeriodID) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.SubprojectPerformanceMeasureActualID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            
+            this.SubprojectID = subprojectID;
+            this.PerformanceMeasureID = performanceMeasureID;
+            this.ActualValue = actualValue;
+            this.PerformanceMeasureReportingPeriodID = performanceMeasureReportingPeriodID;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields, using objects whenever possible
+        /// </summary>
+        public SubprojectPerformanceMeasureActual(Subproject subproject, PerformanceMeasure performanceMeasure, double actualValue, PerformanceMeasureReportingPeriod performanceMeasureReportingPeriod) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.SubprojectPerformanceMeasureActualID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            this.SubprojectID = subproject.SubprojectID;
+            this.Subproject = subproject;
+            subproject.SubprojectPerformanceMeasureActuals.Add(this);
+            this.PerformanceMeasureID = performanceMeasure.PerformanceMeasureID;
+            this.PerformanceMeasure = performanceMeasure;
+            performanceMeasure.SubprojectPerformanceMeasureActuals.Add(this);
+            this.ActualValue = actualValue;
+            this.PerformanceMeasureReportingPeriodID = performanceMeasureReportingPeriod.PerformanceMeasureReportingPeriodID;
+            this.PerformanceMeasureReportingPeriod = performanceMeasureReportingPeriod;
+            performanceMeasureReportingPeriod.SubprojectPerformanceMeasureActuals.Add(this);
+        }
+
+        /// <summary>
+        /// Creates a "blank" object of this type and populates primitives with defaults
+        /// </summary>
+        public static SubprojectPerformanceMeasureActual CreateNewBlank(Subproject subproject, PerformanceMeasure performanceMeasure, PerformanceMeasureReportingPeriod performanceMeasureReportingPeriod)
+        {
+            return new SubprojectPerformanceMeasureActual(subproject, performanceMeasure, default(double), performanceMeasureReportingPeriod);
+        }
+
+        /// <summary>
+        /// Does this object have any dependent objects? (If it does have dependent objects, these would need to be deleted before this object could be deleted.)
+        /// </summary>
+        /// <returns></returns>
+        public bool HasDependentObjects()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Active Dependent type names of this object
+        /// </summary>
+        public List<string> DependentObjectNames() 
+        {
+            var dependentObjects = new List<string>();
+            
+            return dependentObjects.Distinct().ToList();
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(SubprojectPerformanceMeasureActual).Name};
+
+
+        /// <summary>
+        /// Delete just the entity 
+        /// </summary>
+        public void Delete(DatabaseEntities dbContext)
+        {
+            dbContext.AllSubprojectPerformanceMeasureActuals.Remove(this);
+        }
+        
+        /// <summary>
+        /// Delete entity plus all children
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            
+            Delete(dbContext);
+        }
+
+        [Key]
+        public int SubprojectPerformanceMeasureActualID { get; set; }
+        public int TenantID { get; set; }
+        public int SubprojectID { get; set; }
+        public int PerformanceMeasureID { get; set; }
+        public double ActualValue { get; set; }
+        public int PerformanceMeasureReportingPeriodID { get; set; }
+        [NotMapped]
+        public int PrimaryKey { get { return SubprojectPerformanceMeasureActualID; } set { SubprojectPerformanceMeasureActualID = value; } }
+
+        public Tenant Tenant { get { return Tenant.AllLookupDictionary[TenantID]; } }
+        public virtual Subproject Subproject { get; set; }
+        public virtual PerformanceMeasure PerformanceMeasure { get; set; }
+        public virtual PerformanceMeasureReportingPeriod PerformanceMeasureReportingPeriod { get; set; }
+
+        public static class FieldLengths
+        {
+
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActual.DatabaseContextExtensions.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActual.DatabaseContextExtensions.cs
@@ -1,0 +1,24 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureActual]
+using System.Collections.Generic;
+using System.Linq;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public static partial class DatabaseContextExtensions
+    {
+        public static SubprojectPerformanceMeasureActual GetSubprojectPerformanceMeasureActual(this IQueryable<SubprojectPerformanceMeasureActual> subprojectPerformanceMeasureActuals, int subprojectPerformanceMeasureActualID)
+        {
+            var subprojectPerformanceMeasureActual = subprojectPerformanceMeasureActuals.SingleOrDefault(x => x.SubprojectPerformanceMeasureActualID == subprojectPerformanceMeasureActualID);
+            Check.RequireNotNullThrowNotFound(subprojectPerformanceMeasureActual, "SubprojectPerformanceMeasureActual", subprojectPerformanceMeasureActualID);
+            return subprojectPerformanceMeasureActual;
+        }
+
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualConfiguration.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualConfiguration.Binding.cs
@@ -1,0 +1,31 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureActual]
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity.ModelConfiguration;
+
+namespace ProjectFirmaModels.Models
+{
+    public class SubprojectPerformanceMeasureActualConfiguration : EntityTypeConfiguration<SubprojectPerformanceMeasureActual>
+    {
+        public SubprojectPerformanceMeasureActualConfiguration() : this("dbo"){}
+
+        public SubprojectPerformanceMeasureActualConfiguration(string schema)
+        {
+            ToTable("SubprojectPerformanceMeasureActual", schema);
+            HasKey(x => x.SubprojectPerformanceMeasureActualID);
+            Property(x => x.SubprojectPerformanceMeasureActualID).HasColumnName(@"SubprojectPerformanceMeasureActualID").HasColumnType("int").IsRequired().HasDatabaseGeneratedOption(DatabaseGeneratedOption.Identity);
+            Property(x => x.TenantID).HasColumnName(@"TenantID").HasColumnType("int").IsRequired();
+            Property(x => x.SubprojectID).HasColumnName(@"SubprojectID").HasColumnType("int").IsRequired();
+            Property(x => x.PerformanceMeasureID).HasColumnName(@"PerformanceMeasureID").HasColumnType("int").IsRequired();
+            Property(x => x.ActualValue).HasColumnName(@"ActualValue").HasColumnType("float").IsRequired();
+            Property(x => x.PerformanceMeasureReportingPeriodID).HasColumnName(@"PerformanceMeasureReportingPeriodID").HasColumnType("int").IsRequired();
+
+            // Foreign keys
+            HasRequired(a => a.Subproject).WithMany(b => b.SubprojectPerformanceMeasureActuals).HasForeignKey(c => c.SubprojectID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureActual_Subproject_SubprojectID
+            HasRequired(a => a.PerformanceMeasure).WithMany(b => b.SubprojectPerformanceMeasureActuals).HasForeignKey(c => c.PerformanceMeasureID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureActual_PerformanceMeasure_PerformanceMeasureID
+            HasRequired(a => a.PerformanceMeasureReportingPeriod).WithMany(b => b.SubprojectPerformanceMeasureActuals).HasForeignKey(c => c.PerformanceMeasureReportingPeriodID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureActual_PerformanceMeasureReportingPeriod_PerformanceMeasureReportingPeriodID
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualPrimaryKey.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualPrimaryKey.Binding.cs
@@ -1,0 +1,27 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: dbo.SubprojectPerformanceMeasureActual
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public class SubprojectPerformanceMeasureActualPrimaryKey : LtInfo.Common.EntityModelBinding.LtInfoEntityPrimaryKey<SubprojectPerformanceMeasureActual>
+    {
+        public SubprojectPerformanceMeasureActualPrimaryKey(int primaryKeyValue) : base(primaryKeyValue){}
+        public SubprojectPerformanceMeasureActualPrimaryKey(SubprojectPerformanceMeasureActual subprojectPerformanceMeasureActual) : base(subprojectPerformanceMeasureActual){}
+
+        public static implicit operator SubprojectPerformanceMeasureActualPrimaryKey(int primaryKeyValue)
+        {
+            return new SubprojectPerformanceMeasureActualPrimaryKey(primaryKeyValue);
+        }
+
+        public static implicit operator SubprojectPerformanceMeasureActualPrimaryKey(SubprojectPerformanceMeasureActual subprojectPerformanceMeasureActual)
+        {
+            return new SubprojectPerformanceMeasureActualPrimaryKey(subprojectPerformanceMeasureActual);
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualSubcategoryOption.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualSubcategoryOption.Binding.cs
@@ -1,0 +1,149 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+using System.Data.Entity.Spatial;
+using System.Linq;
+using System.Web;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    // Table [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption] is multi-tenant, so is attributed as IHaveATenantID
+    [Table("[dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]")]
+    public partial class SubprojectPerformanceMeasureActualSubcategoryOption : IHavePrimaryKey, IHaveATenantID
+    {
+        /// <summary>
+        /// Default Constructor; only used by EF
+        /// </summary>
+        protected SubprojectPerformanceMeasureActualSubcategoryOption()
+        {
+
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MaximalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public SubprojectPerformanceMeasureActualSubcategoryOption(int subprojectPerformanceMeasureActualSubcategoryOptionID, int subprojectPerformanceMeasureActualID, int performanceMeasureSubcategoryOptionID, int performanceMeasureID, int performanceMeasureSubcategoryID) : this()
+        {
+            this.SubprojectPerformanceMeasureActualSubcategoryOptionID = subprojectPerformanceMeasureActualSubcategoryOptionID;
+            this.SubprojectPerformanceMeasureActualID = subprojectPerformanceMeasureActualID;
+            this.PerformanceMeasureSubcategoryOptionID = performanceMeasureSubcategoryOptionID;
+            this.PerformanceMeasureID = performanceMeasureID;
+            this.PerformanceMeasureSubcategoryID = performanceMeasureSubcategoryID;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public SubprojectPerformanceMeasureActualSubcategoryOption(int subprojectPerformanceMeasureActualID, int performanceMeasureSubcategoryOptionID, int performanceMeasureID, int performanceMeasureSubcategoryID) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.SubprojectPerformanceMeasureActualSubcategoryOptionID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            
+            this.SubprojectPerformanceMeasureActualID = subprojectPerformanceMeasureActualID;
+            this.PerformanceMeasureSubcategoryOptionID = performanceMeasureSubcategoryOptionID;
+            this.PerformanceMeasureID = performanceMeasureID;
+            this.PerformanceMeasureSubcategoryID = performanceMeasureSubcategoryID;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields, using objects whenever possible
+        /// </summary>
+        public SubprojectPerformanceMeasureActualSubcategoryOption(PerformanceMeasureActual subprojectPerformanceMeasureActual, PerformanceMeasureSubcategoryOption performanceMeasureSubcategoryOption, PerformanceMeasure performanceMeasure, PerformanceMeasureSubcategory performanceMeasureSubcategory) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.SubprojectPerformanceMeasureActualSubcategoryOptionID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            this.SubprojectPerformanceMeasureActualID = subprojectPerformanceMeasureActual.PerformanceMeasureActualID;
+            this.SubprojectPerformanceMeasureActual = subprojectPerformanceMeasureActual;
+            subprojectPerformanceMeasureActual.SubprojectPerformanceMeasureActualSubcategoryOptionsWhereYouAreTheSubprojectPerformanceMeasureActual.Add(this);
+            this.PerformanceMeasureSubcategoryOptionID = performanceMeasureSubcategoryOption.PerformanceMeasureSubcategoryOptionID;
+            this.PerformanceMeasureSubcategoryOption = performanceMeasureSubcategoryOption;
+            performanceMeasureSubcategoryOption.SubprojectPerformanceMeasureActualSubcategoryOptions.Add(this);
+            this.PerformanceMeasureID = performanceMeasure.PerformanceMeasureID;
+            this.PerformanceMeasure = performanceMeasure;
+            performanceMeasure.SubprojectPerformanceMeasureActualSubcategoryOptions.Add(this);
+            this.PerformanceMeasureSubcategoryID = performanceMeasureSubcategory.PerformanceMeasureSubcategoryID;
+            this.PerformanceMeasureSubcategory = performanceMeasureSubcategory;
+            performanceMeasureSubcategory.SubprojectPerformanceMeasureActualSubcategoryOptions.Add(this);
+        }
+
+        /// <summary>
+        /// Creates a "blank" object of this type and populates primitives with defaults
+        /// </summary>
+        public static SubprojectPerformanceMeasureActualSubcategoryOption CreateNewBlank(PerformanceMeasureActual subprojectPerformanceMeasureActual, PerformanceMeasureSubcategoryOption performanceMeasureSubcategoryOption, PerformanceMeasure performanceMeasure, PerformanceMeasureSubcategory performanceMeasureSubcategory)
+        {
+            return new SubprojectPerformanceMeasureActualSubcategoryOption(subprojectPerformanceMeasureActual, performanceMeasureSubcategoryOption, performanceMeasure, performanceMeasureSubcategory);
+        }
+
+        /// <summary>
+        /// Does this object have any dependent objects? (If it does have dependent objects, these would need to be deleted before this object could be deleted.)
+        /// </summary>
+        /// <returns></returns>
+        public bool HasDependentObjects()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Active Dependent type names of this object
+        /// </summary>
+        public List<string> DependentObjectNames() 
+        {
+            var dependentObjects = new List<string>();
+            
+            return dependentObjects.Distinct().ToList();
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(SubprojectPerformanceMeasureActualSubcategoryOption).Name};
+
+
+        /// <summary>
+        /// Delete just the entity 
+        /// </summary>
+        public void Delete(DatabaseEntities dbContext)
+        {
+            dbContext.AllSubprojectPerformanceMeasureActualSubcategoryOptions.Remove(this);
+        }
+        
+        /// <summary>
+        /// Delete entity plus all children
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            
+            Delete(dbContext);
+        }
+
+        [Key]
+        public int SubprojectPerformanceMeasureActualSubcategoryOptionID { get; set; }
+        public int TenantID { get; set; }
+        public int SubprojectPerformanceMeasureActualID { get; set; }
+        public int PerformanceMeasureSubcategoryOptionID { get; set; }
+        public int PerformanceMeasureID { get; set; }
+        public int PerformanceMeasureSubcategoryID { get; set; }
+        [NotMapped]
+        public int PrimaryKey { get { return SubprojectPerformanceMeasureActualSubcategoryOptionID; } set { SubprojectPerformanceMeasureActualSubcategoryOptionID = value; } }
+
+        public Tenant Tenant { get { return Tenant.AllLookupDictionary[TenantID]; } }
+        public virtual PerformanceMeasureActual SubprojectPerformanceMeasureActual { get; set; }
+        public virtual PerformanceMeasureSubcategoryOption PerformanceMeasureSubcategoryOption { get; set; }
+        public virtual PerformanceMeasure PerformanceMeasure { get; set; }
+        public virtual PerformanceMeasureSubcategory PerformanceMeasureSubcategory { get; set; }
+
+        public static class FieldLengths
+        {
+
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualSubcategoryOption.DatabaseContextExtensions.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualSubcategoryOption.DatabaseContextExtensions.cs
@@ -1,0 +1,24 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]
+using System.Collections.Generic;
+using System.Linq;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public static partial class DatabaseContextExtensions
+    {
+        public static SubprojectPerformanceMeasureActualSubcategoryOption GetSubprojectPerformanceMeasureActualSubcategoryOption(this IQueryable<SubprojectPerformanceMeasureActualSubcategoryOption> subprojectPerformanceMeasureActualSubcategoryOptions, int subprojectPerformanceMeasureActualSubcategoryOptionID)
+        {
+            var subprojectPerformanceMeasureActualSubcategoryOption = subprojectPerformanceMeasureActualSubcategoryOptions.SingleOrDefault(x => x.SubprojectPerformanceMeasureActualSubcategoryOptionID == subprojectPerformanceMeasureActualSubcategoryOptionID);
+            Check.RequireNotNullThrowNotFound(subprojectPerformanceMeasureActualSubcategoryOption, "SubprojectPerformanceMeasureActualSubcategoryOption", subprojectPerformanceMeasureActualSubcategoryOptionID);
+            return subprojectPerformanceMeasureActualSubcategoryOption;
+        }
+
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualSubcategoryOptionConfiguration.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualSubcategoryOptionConfiguration.Binding.cs
@@ -1,0 +1,32 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureActualSubcategoryOption]
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity.ModelConfiguration;
+
+namespace ProjectFirmaModels.Models
+{
+    public class SubprojectPerformanceMeasureActualSubcategoryOptionConfiguration : EntityTypeConfiguration<SubprojectPerformanceMeasureActualSubcategoryOption>
+    {
+        public SubprojectPerformanceMeasureActualSubcategoryOptionConfiguration() : this("dbo"){}
+
+        public SubprojectPerformanceMeasureActualSubcategoryOptionConfiguration(string schema)
+        {
+            ToTable("SubprojectPerformanceMeasureActualSubcategoryOption", schema);
+            HasKey(x => x.SubprojectPerformanceMeasureActualSubcategoryOptionID);
+            Property(x => x.SubprojectPerformanceMeasureActualSubcategoryOptionID).HasColumnName(@"SubprojectPerformanceMeasureActualSubcategoryOptionID").HasColumnType("int").IsRequired().HasDatabaseGeneratedOption(DatabaseGeneratedOption.Identity);
+            Property(x => x.TenantID).HasColumnName(@"TenantID").HasColumnType("int").IsRequired();
+            Property(x => x.SubprojectPerformanceMeasureActualID).HasColumnName(@"SubprojectPerformanceMeasureActualID").HasColumnType("int").IsRequired();
+            Property(x => x.PerformanceMeasureSubcategoryOptionID).HasColumnName(@"PerformanceMeasureSubcategoryOptionID").HasColumnType("int").IsRequired();
+            Property(x => x.PerformanceMeasureID).HasColumnName(@"PerformanceMeasureID").HasColumnType("int").IsRequired();
+            Property(x => x.PerformanceMeasureSubcategoryID).HasColumnName(@"PerformanceMeasureSubcategoryID").HasColumnType("int").IsRequired();
+
+            // Foreign keys
+            HasRequired(a => a.SubprojectPerformanceMeasureActual).WithMany(b => b.SubprojectPerformanceMeasureActualSubcategoryOptionsWhereYouAreTheSubprojectPerformanceMeasureActual).HasForeignKey(c => c.SubprojectPerformanceMeasureActualID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureActual_SubprojectPerformanceMeasureActualID_Performance
+            HasRequired(a => a.PerformanceMeasureSubcategoryOption).WithMany(b => b.SubprojectPerformanceMeasureActualSubcategoryOptions).HasForeignKey(c => c.PerformanceMeasureSubcategoryOptionID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOptionID
+            HasRequired(a => a.PerformanceMeasure).WithMany(b => b.SubprojectPerformanceMeasureActualSubcategoryOptions).HasForeignKey(c => c.PerformanceMeasureID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasure_PerformanceMeasureID
+            HasRequired(a => a.PerformanceMeasureSubcategory).WithMany(b => b.SubprojectPerformanceMeasureActualSubcategoryOptions).HasForeignKey(c => c.PerformanceMeasureSubcategoryID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureActualSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualSubcategoryOptionPrimaryKey.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureActualSubcategoryOptionPrimaryKey.Binding.cs
@@ -1,0 +1,27 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: dbo.SubprojectPerformanceMeasureActualSubcategoryOption
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public class SubprojectPerformanceMeasureActualSubcategoryOptionPrimaryKey : LtInfo.Common.EntityModelBinding.LtInfoEntityPrimaryKey<SubprojectPerformanceMeasureActualSubcategoryOption>
+    {
+        public SubprojectPerformanceMeasureActualSubcategoryOptionPrimaryKey(int primaryKeyValue) : base(primaryKeyValue){}
+        public SubprojectPerformanceMeasureActualSubcategoryOptionPrimaryKey(SubprojectPerformanceMeasureActualSubcategoryOption subprojectPerformanceMeasureActualSubcategoryOption) : base(subprojectPerformanceMeasureActualSubcategoryOption){}
+
+        public static implicit operator SubprojectPerformanceMeasureActualSubcategoryOptionPrimaryKey(int primaryKeyValue)
+        {
+            return new SubprojectPerformanceMeasureActualSubcategoryOptionPrimaryKey(primaryKeyValue);
+        }
+
+        public static implicit operator SubprojectPerformanceMeasureActualSubcategoryOptionPrimaryKey(SubprojectPerformanceMeasureActualSubcategoryOption subprojectPerformanceMeasureActualSubcategoryOption)
+        {
+            return new SubprojectPerformanceMeasureActualSubcategoryOptionPrimaryKey(subprojectPerformanceMeasureActualSubcategoryOption);
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpected.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpected.Binding.cs
@@ -1,0 +1,153 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureExpected]
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+using System.Data.Entity.Spatial;
+using System.Linq;
+using System.Web;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    // Table [dbo].[SubprojectPerformanceMeasureExpected] is multi-tenant, so is attributed as IHaveATenantID
+    [Table("[dbo].[SubprojectPerformanceMeasureExpected]")]
+    public partial class SubprojectPerformanceMeasureExpected : IHavePrimaryKey, IHaveATenantID
+    {
+        /// <summary>
+        /// Default Constructor; only used by EF
+        /// </summary>
+        protected SubprojectPerformanceMeasureExpected()
+        {
+            this.SubprojectPerformanceMeasureExpectedSubcategoryOptions = new HashSet<SubprojectPerformanceMeasureExpectedSubcategoryOption>();
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MaximalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public SubprojectPerformanceMeasureExpected(int subprojectPerformanceMeasureExpectedID, int subprojectID, int performanceMeasureID, double? expectedValue) : this()
+        {
+            this.SubprojectPerformanceMeasureExpectedID = subprojectPerformanceMeasureExpectedID;
+            this.SubprojectID = subprojectID;
+            this.PerformanceMeasureID = performanceMeasureID;
+            this.ExpectedValue = expectedValue;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public SubprojectPerformanceMeasureExpected(int subprojectID, int performanceMeasureID) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.SubprojectPerformanceMeasureExpectedID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            
+            this.SubprojectID = subprojectID;
+            this.PerformanceMeasureID = performanceMeasureID;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields, using objects whenever possible
+        /// </summary>
+        public SubprojectPerformanceMeasureExpected(Subproject subproject, PerformanceMeasure performanceMeasure) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.SubprojectPerformanceMeasureExpectedID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            this.SubprojectID = subproject.SubprojectID;
+            this.Subproject = subproject;
+            subproject.SubprojectPerformanceMeasureExpecteds.Add(this);
+            this.PerformanceMeasureID = performanceMeasure.PerformanceMeasureID;
+            this.PerformanceMeasure = performanceMeasure;
+            performanceMeasure.SubprojectPerformanceMeasureExpecteds.Add(this);
+        }
+
+        /// <summary>
+        /// Creates a "blank" object of this type and populates primitives with defaults
+        /// </summary>
+        public static SubprojectPerformanceMeasureExpected CreateNewBlank(Subproject subproject, PerformanceMeasure performanceMeasure)
+        {
+            return new SubprojectPerformanceMeasureExpected(subproject, performanceMeasure);
+        }
+
+        /// <summary>
+        /// Does this object have any dependent objects? (If it does have dependent objects, these would need to be deleted before this object could be deleted.)
+        /// </summary>
+        /// <returns></returns>
+        public bool HasDependentObjects()
+        {
+            return SubprojectPerformanceMeasureExpectedSubcategoryOptions.Any();
+        }
+
+        /// <summary>
+        /// Active Dependent type names of this object
+        /// </summary>
+        public List<string> DependentObjectNames() 
+        {
+            var dependentObjects = new List<string>();
+            
+            if(SubprojectPerformanceMeasureExpectedSubcategoryOptions.Any())
+            {
+                dependentObjects.Add(typeof(SubprojectPerformanceMeasureExpectedSubcategoryOption).Name);
+            }
+            return dependentObjects.Distinct().ToList();
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(SubprojectPerformanceMeasureExpected).Name, typeof(SubprojectPerformanceMeasureExpectedSubcategoryOption).Name};
+
+
+        /// <summary>
+        /// Delete just the entity 
+        /// </summary>
+        public void Delete(DatabaseEntities dbContext)
+        {
+            dbContext.AllSubprojectPerformanceMeasureExpecteds.Remove(this);
+        }
+        
+        /// <summary>
+        /// Delete entity plus all children
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            DeleteChildren(dbContext);
+            Delete(dbContext);
+        }
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public void DeleteChildren(DatabaseEntities dbContext)
+        {
+
+            foreach(var x in SubprojectPerformanceMeasureExpectedSubcategoryOptions.ToList())
+            {
+                x.DeleteFull(dbContext);
+            }
+        }
+
+        [Key]
+        public int SubprojectPerformanceMeasureExpectedID { get; set; }
+        public int TenantID { get; set; }
+        public int SubprojectID { get; set; }
+        public int PerformanceMeasureID { get; set; }
+        public double? ExpectedValue { get; set; }
+        [NotMapped]
+        public int PrimaryKey { get { return SubprojectPerformanceMeasureExpectedID; } set { SubprojectPerformanceMeasureExpectedID = value; } }
+
+        public virtual ICollection<SubprojectPerformanceMeasureExpectedSubcategoryOption> SubprojectPerformanceMeasureExpectedSubcategoryOptions { get; set; }
+        public Tenant Tenant { get { return Tenant.AllLookupDictionary[TenantID]; } }
+        public virtual Subproject Subproject { get; set; }
+        public virtual PerformanceMeasure PerformanceMeasure { get; set; }
+
+        public static class FieldLengths
+        {
+
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpected.DatabaseContextExtensions.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpected.DatabaseContextExtensions.cs
@@ -1,0 +1,24 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureExpected]
+using System.Collections.Generic;
+using System.Linq;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public static partial class DatabaseContextExtensions
+    {
+        public static SubprojectPerformanceMeasureExpected GetSubprojectPerformanceMeasureExpected(this IQueryable<SubprojectPerformanceMeasureExpected> subprojectPerformanceMeasureExpecteds, int subprojectPerformanceMeasureExpectedID)
+        {
+            var subprojectPerformanceMeasureExpected = subprojectPerformanceMeasureExpecteds.SingleOrDefault(x => x.SubprojectPerformanceMeasureExpectedID == subprojectPerformanceMeasureExpectedID);
+            Check.RequireNotNullThrowNotFound(subprojectPerformanceMeasureExpected, "SubprojectPerformanceMeasureExpected", subprojectPerformanceMeasureExpectedID);
+            return subprojectPerformanceMeasureExpected;
+        }
+
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedConfiguration.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedConfiguration.Binding.cs
@@ -1,0 +1,29 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureExpected]
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity.ModelConfiguration;
+
+namespace ProjectFirmaModels.Models
+{
+    public class SubprojectPerformanceMeasureExpectedConfiguration : EntityTypeConfiguration<SubprojectPerformanceMeasureExpected>
+    {
+        public SubprojectPerformanceMeasureExpectedConfiguration() : this("dbo"){}
+
+        public SubprojectPerformanceMeasureExpectedConfiguration(string schema)
+        {
+            ToTable("SubprojectPerformanceMeasureExpected", schema);
+            HasKey(x => x.SubprojectPerformanceMeasureExpectedID);
+            Property(x => x.SubprojectPerformanceMeasureExpectedID).HasColumnName(@"SubprojectPerformanceMeasureExpectedID").HasColumnType("int").IsRequired().HasDatabaseGeneratedOption(DatabaseGeneratedOption.Identity);
+            Property(x => x.TenantID).HasColumnName(@"TenantID").HasColumnType("int").IsRequired();
+            Property(x => x.SubprojectID).HasColumnName(@"SubprojectID").HasColumnType("int").IsRequired();
+            Property(x => x.PerformanceMeasureID).HasColumnName(@"PerformanceMeasureID").HasColumnType("int").IsRequired();
+            Property(x => x.ExpectedValue).HasColumnName(@"ExpectedValue").HasColumnType("float").IsOptional();
+
+            // Foreign keys
+            HasRequired(a => a.Subproject).WithMany(b => b.SubprojectPerformanceMeasureExpecteds).HasForeignKey(c => c.SubprojectID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureExpected_Subproject_SubprojectID
+            HasRequired(a => a.PerformanceMeasure).WithMany(b => b.SubprojectPerformanceMeasureExpecteds).HasForeignKey(c => c.PerformanceMeasureID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureExpected_PerformanceMeasure_PerformanceMeasureID
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedPrimaryKey.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedPrimaryKey.Binding.cs
@@ -1,0 +1,27 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: dbo.SubprojectPerformanceMeasureExpected
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public class SubprojectPerformanceMeasureExpectedPrimaryKey : LtInfo.Common.EntityModelBinding.LtInfoEntityPrimaryKey<SubprojectPerformanceMeasureExpected>
+    {
+        public SubprojectPerformanceMeasureExpectedPrimaryKey(int primaryKeyValue) : base(primaryKeyValue){}
+        public SubprojectPerformanceMeasureExpectedPrimaryKey(SubprojectPerformanceMeasureExpected subprojectPerformanceMeasureExpected) : base(subprojectPerformanceMeasureExpected){}
+
+        public static implicit operator SubprojectPerformanceMeasureExpectedPrimaryKey(int primaryKeyValue)
+        {
+            return new SubprojectPerformanceMeasureExpectedPrimaryKey(primaryKeyValue);
+        }
+
+        public static implicit operator SubprojectPerformanceMeasureExpectedPrimaryKey(SubprojectPerformanceMeasureExpected subprojectPerformanceMeasureExpected)
+        {
+            return new SubprojectPerformanceMeasureExpectedPrimaryKey(subprojectPerformanceMeasureExpected);
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedSubcategoryOption.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedSubcategoryOption.Binding.cs
@@ -1,0 +1,149 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+using System.Data.Entity.Spatial;
+using System.Linq;
+using System.Web;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    // Table [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption] is multi-tenant, so is attributed as IHaveATenantID
+    [Table("[dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]")]
+    public partial class SubprojectPerformanceMeasureExpectedSubcategoryOption : IHavePrimaryKey, IHaveATenantID
+    {
+        /// <summary>
+        /// Default Constructor; only used by EF
+        /// </summary>
+        protected SubprojectPerformanceMeasureExpectedSubcategoryOption()
+        {
+
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MaximalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public SubprojectPerformanceMeasureExpectedSubcategoryOption(int subprojectPerformanceMeasureExpectedSubcategoryOptionID, int subprojectPerformanceMeasureExpectedID, int performanceMeasureSubcategoryOptionID, int performanceMeasureID, int performanceMeasureSubcategoryID) : this()
+        {
+            this.SubprojectPerformanceMeasureExpectedSubcategoryOptionID = subprojectPerformanceMeasureExpectedSubcategoryOptionID;
+            this.SubprojectPerformanceMeasureExpectedID = subprojectPerformanceMeasureExpectedID;
+            this.PerformanceMeasureSubcategoryOptionID = performanceMeasureSubcategoryOptionID;
+            this.PerformanceMeasureID = performanceMeasureID;
+            this.PerformanceMeasureSubcategoryID = performanceMeasureSubcategoryID;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public SubprojectPerformanceMeasureExpectedSubcategoryOption(int subprojectPerformanceMeasureExpectedID, int performanceMeasureSubcategoryOptionID, int performanceMeasureID, int performanceMeasureSubcategoryID) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.SubprojectPerformanceMeasureExpectedSubcategoryOptionID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            
+            this.SubprojectPerformanceMeasureExpectedID = subprojectPerformanceMeasureExpectedID;
+            this.PerformanceMeasureSubcategoryOptionID = performanceMeasureSubcategoryOptionID;
+            this.PerformanceMeasureID = performanceMeasureID;
+            this.PerformanceMeasureSubcategoryID = performanceMeasureSubcategoryID;
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MinimalConstructor required fields, using objects whenever possible
+        /// </summary>
+        public SubprojectPerformanceMeasureExpectedSubcategoryOption(SubprojectPerformanceMeasureExpected subprojectPerformanceMeasureExpected, PerformanceMeasureSubcategoryOption performanceMeasureSubcategoryOption, PerformanceMeasure performanceMeasure, PerformanceMeasureSubcategory performanceMeasureSubcategory) : this()
+        {
+            // Mark this as a new object by setting primary key with special value
+            this.SubprojectPerformanceMeasureExpectedSubcategoryOptionID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
+            this.SubprojectPerformanceMeasureExpectedID = subprojectPerformanceMeasureExpected.SubprojectPerformanceMeasureExpectedID;
+            this.SubprojectPerformanceMeasureExpected = subprojectPerformanceMeasureExpected;
+            subprojectPerformanceMeasureExpected.SubprojectPerformanceMeasureExpectedSubcategoryOptions.Add(this);
+            this.PerformanceMeasureSubcategoryOptionID = performanceMeasureSubcategoryOption.PerformanceMeasureSubcategoryOptionID;
+            this.PerformanceMeasureSubcategoryOption = performanceMeasureSubcategoryOption;
+            performanceMeasureSubcategoryOption.SubprojectPerformanceMeasureExpectedSubcategoryOptions.Add(this);
+            this.PerformanceMeasureID = performanceMeasure.PerformanceMeasureID;
+            this.PerformanceMeasure = performanceMeasure;
+            performanceMeasure.SubprojectPerformanceMeasureExpectedSubcategoryOptions.Add(this);
+            this.PerformanceMeasureSubcategoryID = performanceMeasureSubcategory.PerformanceMeasureSubcategoryID;
+            this.PerformanceMeasureSubcategory = performanceMeasureSubcategory;
+            performanceMeasureSubcategory.SubprojectPerformanceMeasureExpectedSubcategoryOptions.Add(this);
+        }
+
+        /// <summary>
+        /// Creates a "blank" object of this type and populates primitives with defaults
+        /// </summary>
+        public static SubprojectPerformanceMeasureExpectedSubcategoryOption CreateNewBlank(SubprojectPerformanceMeasureExpected subprojectPerformanceMeasureExpected, PerformanceMeasureSubcategoryOption performanceMeasureSubcategoryOption, PerformanceMeasure performanceMeasure, PerformanceMeasureSubcategory performanceMeasureSubcategory)
+        {
+            return new SubprojectPerformanceMeasureExpectedSubcategoryOption(subprojectPerformanceMeasureExpected, performanceMeasureSubcategoryOption, performanceMeasure, performanceMeasureSubcategory);
+        }
+
+        /// <summary>
+        /// Does this object have any dependent objects? (If it does have dependent objects, these would need to be deleted before this object could be deleted.)
+        /// </summary>
+        /// <returns></returns>
+        public bool HasDependentObjects()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Active Dependent type names of this object
+        /// </summary>
+        public List<string> DependentObjectNames() 
+        {
+            var dependentObjects = new List<string>();
+            
+            return dependentObjects.Distinct().ToList();
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(SubprojectPerformanceMeasureExpectedSubcategoryOption).Name};
+
+
+        /// <summary>
+        /// Delete just the entity 
+        /// </summary>
+        public void Delete(DatabaseEntities dbContext)
+        {
+            dbContext.AllSubprojectPerformanceMeasureExpectedSubcategoryOptions.Remove(this);
+        }
+        
+        /// <summary>
+        /// Delete entity plus all children
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            
+            Delete(dbContext);
+        }
+
+        [Key]
+        public int SubprojectPerformanceMeasureExpectedSubcategoryOptionID { get; set; }
+        public int TenantID { get; set; }
+        public int SubprojectPerformanceMeasureExpectedID { get; set; }
+        public int PerformanceMeasureSubcategoryOptionID { get; set; }
+        public int PerformanceMeasureID { get; set; }
+        public int PerformanceMeasureSubcategoryID { get; set; }
+        [NotMapped]
+        public int PrimaryKey { get { return SubprojectPerformanceMeasureExpectedSubcategoryOptionID; } set { SubprojectPerformanceMeasureExpectedSubcategoryOptionID = value; } }
+
+        public Tenant Tenant { get { return Tenant.AllLookupDictionary[TenantID]; } }
+        public virtual SubprojectPerformanceMeasureExpected SubprojectPerformanceMeasureExpected { get; set; }
+        public virtual PerformanceMeasureSubcategoryOption PerformanceMeasureSubcategoryOption { get; set; }
+        public virtual PerformanceMeasure PerformanceMeasure { get; set; }
+        public virtual PerformanceMeasureSubcategory PerformanceMeasureSubcategory { get; set; }
+
+        public static class FieldLengths
+        {
+
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedSubcategoryOption.DatabaseContextExtensions.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedSubcategoryOption.DatabaseContextExtensions.cs
@@ -1,0 +1,24 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]
+using System.Collections.Generic;
+using System.Linq;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public static partial class DatabaseContextExtensions
+    {
+        public static SubprojectPerformanceMeasureExpectedSubcategoryOption GetSubprojectPerformanceMeasureExpectedSubcategoryOption(this IQueryable<SubprojectPerformanceMeasureExpectedSubcategoryOption> subprojectPerformanceMeasureExpectedSubcategoryOptions, int subprojectPerformanceMeasureExpectedSubcategoryOptionID)
+        {
+            var subprojectPerformanceMeasureExpectedSubcategoryOption = subprojectPerformanceMeasureExpectedSubcategoryOptions.SingleOrDefault(x => x.SubprojectPerformanceMeasureExpectedSubcategoryOptionID == subprojectPerformanceMeasureExpectedSubcategoryOptionID);
+            Check.RequireNotNullThrowNotFound(subprojectPerformanceMeasureExpectedSubcategoryOption, "SubprojectPerformanceMeasureExpectedSubcategoryOption", subprojectPerformanceMeasureExpectedSubcategoryOptionID);
+            return subprojectPerformanceMeasureExpectedSubcategoryOption;
+        }
+
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedSubcategoryOptionConfiguration.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedSubcategoryOptionConfiguration.Binding.cs
@@ -1,0 +1,32 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[SubprojectPerformanceMeasureExpectedSubcategoryOption]
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity.ModelConfiguration;
+
+namespace ProjectFirmaModels.Models
+{
+    public class SubprojectPerformanceMeasureExpectedSubcategoryOptionConfiguration : EntityTypeConfiguration<SubprojectPerformanceMeasureExpectedSubcategoryOption>
+    {
+        public SubprojectPerformanceMeasureExpectedSubcategoryOptionConfiguration() : this("dbo"){}
+
+        public SubprojectPerformanceMeasureExpectedSubcategoryOptionConfiguration(string schema)
+        {
+            ToTable("SubprojectPerformanceMeasureExpectedSubcategoryOption", schema);
+            HasKey(x => x.SubprojectPerformanceMeasureExpectedSubcategoryOptionID);
+            Property(x => x.SubprojectPerformanceMeasureExpectedSubcategoryOptionID).HasColumnName(@"SubprojectPerformanceMeasureExpectedSubcategoryOptionID").HasColumnType("int").IsRequired().HasDatabaseGeneratedOption(DatabaseGeneratedOption.Identity);
+            Property(x => x.TenantID).HasColumnName(@"TenantID").HasColumnType("int").IsRequired();
+            Property(x => x.SubprojectPerformanceMeasureExpectedID).HasColumnName(@"SubprojectPerformanceMeasureExpectedID").HasColumnType("int").IsRequired();
+            Property(x => x.PerformanceMeasureSubcategoryOptionID).HasColumnName(@"PerformanceMeasureSubcategoryOptionID").HasColumnType("int").IsRequired();
+            Property(x => x.PerformanceMeasureID).HasColumnName(@"PerformanceMeasureID").HasColumnType("int").IsRequired();
+            Property(x => x.PerformanceMeasureSubcategoryID).HasColumnName(@"PerformanceMeasureSubcategoryID").HasColumnType("int").IsRequired();
+
+            // Foreign keys
+            HasRequired(a => a.SubprojectPerformanceMeasureExpected).WithMany(b => b.SubprojectPerformanceMeasureExpectedSubcategoryOptions).HasForeignKey(c => c.SubprojectPerformanceMeasureExpectedID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_SubprojectPerformanceMeasureExpected_SubprojectPerformanceMeasureExpect
+            HasRequired(a => a.PerformanceMeasureSubcategoryOption).WithMany(b => b.SubprojectPerformanceMeasureExpectedSubcategoryOptions).HasForeignKey(c => c.PerformanceMeasureSubcategoryOptionID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategoryOption_PerformanceMeasureSubcategoryOption
+            HasRequired(a => a.PerformanceMeasure).WithMany(b => b.SubprojectPerformanceMeasureExpectedSubcategoryOptions).HasForeignKey(c => c.PerformanceMeasureID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasure_PerformanceMeasureID
+            HasRequired(a => a.PerformanceMeasureSubcategory).WithMany(b => b.SubprojectPerformanceMeasureExpectedSubcategoryOptions).HasForeignKey(c => c.PerformanceMeasureSubcategoryID).WillCascadeOnDelete(false); // FK_SubprojectPerformanceMeasureExpectedSubcategoryOption_PerformanceMeasureSubcategory_PerformanceMeasureSubcategoryID
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedSubcategoryOptionPrimaryKey.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPerformanceMeasureExpectedSubcategoryOptionPrimaryKey.Binding.cs
@@ -1,0 +1,27 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: dbo.SubprojectPerformanceMeasureExpectedSubcategoryOption
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public class SubprojectPerformanceMeasureExpectedSubcategoryOptionPrimaryKey : LtInfo.Common.EntityModelBinding.LtInfoEntityPrimaryKey<SubprojectPerformanceMeasureExpectedSubcategoryOption>
+    {
+        public SubprojectPerformanceMeasureExpectedSubcategoryOptionPrimaryKey(int primaryKeyValue) : base(primaryKeyValue){}
+        public SubprojectPerformanceMeasureExpectedSubcategoryOptionPrimaryKey(SubprojectPerformanceMeasureExpectedSubcategoryOption subprojectPerformanceMeasureExpectedSubcategoryOption) : base(subprojectPerformanceMeasureExpectedSubcategoryOption){}
+
+        public static implicit operator SubprojectPerformanceMeasureExpectedSubcategoryOptionPrimaryKey(int primaryKeyValue)
+        {
+            return new SubprojectPerformanceMeasureExpectedSubcategoryOptionPrimaryKey(primaryKeyValue);
+        }
+
+        public static implicit operator SubprojectPerformanceMeasureExpectedSubcategoryOptionPrimaryKey(SubprojectPerformanceMeasureExpectedSubcategoryOption subprojectPerformanceMeasureExpectedSubcategoryOption)
+        {
+            return new SubprojectPerformanceMeasureExpectedSubcategoryOptionPrimaryKey(subprojectPerformanceMeasureExpectedSubcategoryOption);
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/SubprojectPrimaryKey.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/SubprojectPrimaryKey.Binding.cs
@@ -1,0 +1,27 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: dbo.Subproject
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public class SubprojectPrimaryKey : LtInfo.Common.EntityModelBinding.LtInfoEntityPrimaryKey<Subproject>
+    {
+        public SubprojectPrimaryKey(int primaryKeyValue) : base(primaryKeyValue){}
+        public SubprojectPrimaryKey(Subproject subproject) : base(subproject){}
+
+        public static implicit operator SubprojectPrimaryKey(int primaryKeyValue)
+        {
+            return new SubprojectPrimaryKey(primaryKeyValue);
+        }
+
+        public static implicit operator SubprojectPrimaryKey(Subproject subproject)
+        {
+            return new SubprojectPrimaryKey(subproject);
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/ProjectFirmaModels.csproj
+++ b/Source/ProjectFirmaModels/ProjectFirmaModels.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -901,6 +901,26 @@
     <Compile Include="Models\Generated\SubbasinLiasonConfiguration.Binding.cs" />
     <Compile Include="Models\Generated\SubbasinLiasonPrimaryKey.Binding.cs" />
     <Compile Include="Models\Generated\SubbasinPrimaryKey.Binding.cs" />
+    <Compile Include="Models\Generated\Subproject.Binding.cs" />
+    <Compile Include="Models\Generated\Subproject.DatabaseContextExtensions.cs" />
+    <Compile Include="Models\Generated\SubprojectConfiguration.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureActual.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureActual.DatabaseContextExtensions.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureActualConfiguration.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureActualPrimaryKey.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureActualSubcategoryOption.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureActualSubcategoryOption.DatabaseContextExtensions.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureActualSubcategoryOptionConfiguration.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureActualSubcategoryOptionPrimaryKey.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureExpected.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureExpected.DatabaseContextExtensions.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureExpectedConfiguration.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureExpectedPrimaryKey.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureExpectedSubcategoryOption.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureExpectedSubcategoryOption.DatabaseContextExtensions.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureExpectedSubcategoryOptionConfiguration.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPerformanceMeasureExpectedSubcategoryOptionPrimaryKey.Binding.cs" />
+    <Compile Include="Models\Generated\SubprojectPrimaryKey.Binding.cs" />
     <Compile Include="Models\Generated\SupportRequestLog.Binding.cs" />
     <Compile Include="Models\Generated\SupportRequestLog.DatabaseContextExtensions.cs" />
     <Compile Include="Models\Generated\SupportRequestLogConfiguration.Binding.cs" />


### PR DESCRIPTION
Creates Subproject, SubprojectPerformanceMeasureActual, SubprojectPerformanceMeasureExpected, SubprojectPerformanceMeasureActualSubcategoryOption and SubprojectPerformanceMeasureExpectedSubcategoryOption tables. Creates permissions for reading and creating/editing a subproject.