### PR TITLE
Features/pf 2482 make funding source table column headers and row headers sticky

### DIFF
--- a/Source/ProjectFirma.Web/Views/ProjectFundingSourceBudget/EditProjectFundingSourceBudgetByCostType.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectFundingSourceBudget/EditProjectFundingSourceBudgetByCostType.cshtml
@@ -87,6 +87,45 @@ Source code is available upon request via <support@sitkatech.com>.
         font-size: 14px;
     }
 
+    table.tableFixedHead {
+        border-collapse: separate;
+    }
+
+        table.tableFixedHead tbody {
+            overflow-y: auto;
+        }
+
+        table.tableFixedHead thead {
+            position: sticky;
+            top: 0;
+            z-index: 1;
+            background-color: #fff;
+        }
+
+    th.centeredWithTopBorder {
+        text-align: center;
+        border-top: 1px solid #ddd !important;
+    }
+
+    table.tableFixedFirstColumn {
+        border-collapse: separate;
+    }
+
+        table.tableFixedFirstColumn thead tr:first-child th:first-child {
+            position: sticky;
+            top: 0;
+            left: 0;
+            z-index: 2;
+            background-color: #fff;
+        }
+
+        table.tableFixedFirstColumn td:first-child, table.tableFixedFirstColumn th:first-child {
+            position: sticky;
+            left: 0;
+            border: 1px solid #ddd;
+            background-color: #fff;
+        }
+
 </style>
 
 <div class="row">
@@ -161,12 +200,14 @@ Source code is available upon request via <support@sitkatech.com>.
                         </div>
                         <p style="margin-left: 20px" class="systemText" ng-show="getAllUsedFundingSourceIds().length === 0">Add a @ViewDataTyped.FieldDefinitionForFundingSource.GetFieldDefinitionLabel() to start entering budgets</p>
                     </div>
-                    <div style="margin-left: 20px" ng-if="budgetVariesByYear()">
+                    <div style="margin-left: 20px;" ng-if="budgetVariesByYear()">
 
-                        <table class="table-responsive table-condensed table-bordered" style="display: block; overflow: auto;">
+                        <table class="table table-responsive table-condensed table-bordered tableFixedHead tableFixedFirstColumn" style="display: block; overflow: auto; max-height: 800px;">
                             <thead>
                                 <tr>
-                                    <th colspan="2"></th>
+                                    <th rowspan="2" style="white-space: nowrap">
+                                        <span> @Html.LabelWithSugarFor(ViewDataTyped.FieldDefinitionForFundingSource)</span>
+                                    </th>
                                     <th ng-repeat="calendarYear in calendarYearRange" colspan="3" style="text-align: center;">
                                         <span class="glyphicon glyphicon-plus-sign blue pull-left" ng-click="addCalendarYear(calendarYear - 1)" ng-show="$first" title="Add Previous Year {{formatCalendarYear(calendarYear - 1)}}" alt="Add Previous Year {{formatCalendarYear(calendarYear - 1)}}" style="cursor: pointer"></span>
                                         <span class="glyphicon glyphicon-minus-sign blue pull-left" ng-click="deleteCalendarYear(calendarYear)" ng-show="$first && canDeleteCalendarYear(calendarYear)" title="Remove {{formatCalendarYear(calendarYear)}}" alt="Remove {{formatCalendarYear(calendarYear)}}" style="cursor: pointer"></span>
@@ -179,9 +220,6 @@ Source code is available upon request via <support@sitkatech.com>.
                                     </th>
                                 </tr>
                                 <tr ng-show="shouldShowFundingSources()">
-                                    <th style="white-space: nowrap" colspan="2">
-                                        <span> @Html.LabelWithSugarFor(ViewDataTyped.FieldDefinitionForFundingSource)</span>
-                                    </th>
                                     <th ng-repeat-start="calendarYear in calendarYearRange">
                                         <span> @ViewDataTyped.FieldDefinitionForProjectedFunding.GetFieldDefinitionLabel()</span>
                                     </th>
@@ -211,19 +249,17 @@ Source code is available upon request via <support@sitkatech.com>.
                             </thead>
 
                             <tbody ng-show="shouldShowFundingSources()" ng-repeat="fundingSourceID in getAllUsedFundingSourceIds() | orderBy:[getFundingSourceNameById]" style="border-top: 2px solid #ddd">
-                                <tr class="fundingSourceHeaderRow">
-                                    <td style="width: 30px; min-width: 30px;">
-                                        <span class="glyphicon glyphicon-trash blue" title="Remove row" alt="Remove row" ng-click="deleteFundingSourceRow(fundingSourceID)" style="cursor: pointer;"></span>
-                                    </td>
-                                    <td colspan="{{(calendarYearRange.length * 3) + 4}}">
-                                        <label class="control-label">
-                                            <span ng-bind="getFundingSourceNameById(fundingSourceID)"></span>
-                                        </label>
-                                    </td>
-                                </tr>
+                            <tr class="info">
+                                <td colspan="4" style="border-right: 0;">
+                                    <span class="glyphicon glyphicon-trash blue" title="Remove row" alt="Remove row" ng-click="deleteFundingSourceRow(fundingSourceID)" style="cursor: pointer; margin-right: 10px; top: 2px;"></span>
+                                    <label class="control-label" style="margin-bottom: 0;">
+                                        <span ng-bind="getFundingSourceNameById(fundingSourceID)"></span>
+                                    </label>
+                                </td>
+                                <td colspan="{{(calendarYearRange.length * 3)}}" style="border-left: 0;"></td>
+                            </tr>
                                 @* Budget Entry Rows *@
                                 <tr ng-repeat="projectFundingSourceBudget in getProjectFundingSourceBudgetRowsForFundingSource(fundingSourceID) | orderBy:[getFundingSourceName]">
-                                    <td style="width: 30px; min-width: 30px;"></td>
                                     <td ng-bind="getCostTypeName(projectFundingSourceBudget)" />
                                     <td style="text-align: right;" ng-repeat-start="calendarYearBudget in getRelevantCalendarYearBudgets(projectFundingSourceBudget) | orderBy:'CalendarYear'">
 
@@ -248,7 +284,6 @@ Source code is available upon request via <support@sitkatech.com>.
                                 </tr>
                                 @* Sum of budgets for funding source*@
                                 <tr ng-show="getRelevantCostTypes().length > 1">
-                                    <td style="width: 30px; min-width: 30px;"></td>
                                     <th style="white-space: nowrap">
                                         All @ViewDataTyped.FieldDefinitionForCostType.GetFieldDefinitionLabelPluralized()
                                     </th>
@@ -274,12 +309,11 @@ Source code is available upon request via <support@sitkatech.com>.
                             </tbody>
                             @* No Funding Source Identified Yet entry row*@
                         <tbody ng-show="getRelevantCostTypes().length > 0" style="border-top: 2px solid #ddd">
-                            <tr class="fundingSourceHeaderRow">
-                                <td></td>
-                                <td colspan="{{(calendarYearRange.length * 3) + 4}}">@Html.LabelWithSugarFor(@ViewDataTyped.FieldDefinitionForNoFundingSourceIdentified)</td>
-                            </tr>
+                        <tr class="info">
+                            <td colspan="4">@Html.LabelWithSugarFor(@ViewDataTyped.FieldDefinitionForNoFundingSourceIdentified)</td>
+                            <td colspan="{{(calendarYearRange.length * 3)}}"></td>
+                        </tr>
                             <tr ng-repeat="costType in getRelevantCostTypes()">
-                                <td style="width: 30px; min-width: 30px;"></td>
                                 <td ng-bind="costType.CostTypeName" />
                                 <td style="text-align: right;" ng-repeat-start="calendarYearNoFunding in getNoFundingSourceAmounts(costType) | orderBy:'CalendarYear'">
                                     <input type="text" ng-model="calendarYearNoFunding.Amount" ng-focus="onTextFocus($event)" class="sitkaCurrency form-control" ng-currency />
@@ -301,7 +335,7 @@ Source code is available upon request via <support@sitkatech.com>.
                             @* Sum of all budgets and No Funding Source Identified Yet*@
                             <tbody style="border-top: 2px solid #ddd">
                                 <tr>
-                                    <td colspan="2">@Html.LabelWithSugarFor(ViewDataTyped.FieldDefinitionForEstimatedTotalCost)</td>
+                                    <td>@Html.LabelWithSugarFor(ViewDataTyped.FieldDefinitionForEstimatedTotalCost)</td>
                                     <th ng-repeat-start="calendarYear in calendarYearRange" style="text-align: right">
                                         {{getTotalTargetedForCalendarYear(true, calendarYear) | currency:"$"}}
 
@@ -338,11 +372,12 @@ Source code is available upon request via <support@sitkatech.com>.
                         
                     </div>
 
-                    <div style="margin-left: 20px" ng-if="budgetSameEachYear()">
-                        <table class="table-responsive table-condensed table-bordered" style="overflow: auto;">
+                    <div style="margin-left: 20px;" ng-if="budgetSameEachYear()">
+                        
+                        <table class="table table-responsive table-condensed table-bordered tableFixedHead tableFixedFirstColumn" style="display: block; overflow: auto; max-height: 800px; max-width: fit-content;">
                             <thead>
                                 <tr>
-                                    <th style="white-space: nowrap" colspan="2">
+                                    <th style="white-space: nowrap">
                                         <span ng-show="shouldShowFundingSources()"> @Html.LabelWithSugarFor(ViewDataTyped.FieldDefinitionForFundingSource)</span>
                                     </th>
                                     <th>
@@ -363,13 +398,14 @@ Source code is available upon request via <support@sitkatech.com>.
                                 </tr>
                             </thead>
                             <tbody ng-show="shouldShowFundingSources()" ng-repeat="fundingSourceID in getAllUsedFundingSourceIds() | orderBy:[getFundingSourceNameById]" style="border-top: 2px solid #ddd">
-                                <tr class="fundingSourceHeaderRow">
-                                    <td style="width: 30px; min-width: 30px;"><span class="glyphicon glyphicon-trash blue" title="Remove row" alt="Remove row" ng-click="deleteFundingSourceRow(fundingSourceID)" style="cursor: pointer;"></span></td>
-                                    <td colspan="5"><label class="control-label"><span ng-bind="getFundingSourceNameById(fundingSourceID)"></span></label></td>
+                                <tr class="info">
+                                    <td colspan="5">
+                                        <span class="glyphicon glyphicon-trash blue" title="Remove row" alt="Remove row" ng-click="deleteFundingSourceRow(fundingSourceID)" style="cursor: pointer; margin-right: 10px; top: 2px;"></span>
+                                        <label class="control-label"><span ng-bind="getFundingSourceNameById(fundingSourceID)"></span></label>
+                                    </td>
                                 </tr>
                                 @* Budget Entry Rows *@
                                 <tr ng-repeat="projectFundingSourceBudget in getProjectFundingSourceBudgetRowsForFundingSource(fundingSourceID) | orderBy:[getFundingSourceName]">
-                                    <td style="width: 30px; min-width: 30px;"></td>
                                     <td ng-bind="getCostTypeName(projectFundingSourceBudget)" />
                                     <td style="text-align: right;">
                                         <input type="text" ng-model="projectFundingSourceBudget.ProjectedAmount" ng-focus="onTextFocus($event)" class="sitkaCurrency form-control" ng-currency />
@@ -384,7 +420,6 @@ Source code is available upon request via <support@sitkatech.com>.
                                 </tr>
                                 @* Sum of budgets for funding source*@
                                 <tr ng-show="getRelevantCostTypes().length > 1">
-                                    <td style="width: 30px; min-width: 30px;"></td>
                                     <th style="white-space: nowrap">
                                         All @ViewDataTyped.FieldDefinitionForCostType.GetFieldDefinitionLabelPluralized()
                                     </th>
@@ -402,13 +437,8 @@ Source code is available upon request via <support@sitkatech.com>.
                             </tbody>
                             @* No Funding Source Identified Yet entry*@
                             <tbody style="border-top: 2px solid #ddd">
-                                <tr class="fundingSourceHeaderRow">
-                                    <td colspan="2">@Html.LabelWithSugarFor(@ViewDataTyped.FieldDefinitionForNoFundingSourceIdentified)</td>
-                                    <td style="text-align: right">
-                                        @*<input type="text" ng-model="noFundingSourceIdentifiedSameEachYear.Value" ng-focus="onTextFocus($event)" class="sitkaCurrency form-control" ng-currency />*@
-                                    </td>
-                                    <td></td>
-                                    <td></td>
+                                <tr class="info">
+                                    <td colspan="5">@Html.LabelWithSugarFor(@ViewDataTyped.FieldDefinitionForNoFundingSourceIdentified)</td>
                                 </tr>
                                 <tr ng-repeat="noFundingSourceByCostType in getNoFundingSourceAmountsForSameEachYearBudget()">
                                     <td style="width: 30px; min-width: 30px;"></td>

--- a/Source/ProjectFirma.Web/Views/Shared/ExpenditureAndBudgetControls/ProjectBudgetsAnnualByCostType.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ExpenditureAndBudgetControls/ProjectBudgetsAnnualByCostType.cshtml
@@ -43,7 +43,7 @@
         border-collapse: separate;
     }
 
-    table.tableFixedHead tbody { overflow-y: auto; height: 300px; }
+    table.tableFixedHead tbody { overflow-y: auto; }
     table.tableFixedHead thead { position: sticky; top: 0; z-index: 1; background-color: #fff; }
 
     th.centeredWithTopBorder {
@@ -78,7 +78,7 @@
     {
         if (ViewDataTyped.Project.FundingTypeID == FundingType.BudgetVariesByYear.FundingTypeID)
         {
-            <div class="table-responsive tableFixHeader" style="max-height: 600px;">
+            <div class="table-responsive" style="max-height: 800px;">
                 <table class="table table-condensed table-bordered tableFixedHead tableFixedFirstColumn">
                     <thead>
                         <tr>

--- a/Source/ProjectFirma.Web/Views/Shared/ExpenditureAndBudgetControls/ProjectBudgetsAnnualByCostType.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ExpenditureAndBudgetControls/ProjectBudgetsAnnualByCostType.cshtml
@@ -38,6 +38,38 @@
         font-style: italic;
         color: #6e6e6e;
     }
+
+    table.tableFixedHead {
+        border-collapse: separate;
+    }
+
+    table.tableFixedHead tbody { overflow-y: auto; height: 300px; }
+    table.tableFixedHead thead { position: sticky; top: 0; z-index: 1; background-color: #fff; }
+
+    th.centeredWithTopBorder {
+        text-align: center;
+        border-top: 1px solid #ddd !important;
+    }
+
+    table.tableFixedFirstColumn {
+        border-collapse: separate;
+    }
+
+    table.tableFixedFirstColumn thead tr:first-child th:first-child {
+        position: sticky;
+        top: 0;
+        left: 0;
+        z-index: 2;
+        background-color: #fff;
+    }
+
+    table.tableFixedFirstColumn td:first-child {
+        position: sticky;
+        left: 0;
+        border: 1px solid #ddd;
+        background-color: #fff;
+    }
+
 </style>
 <div class="table-responsive" style="margin-top: 25px; overflow-x: hidden">
     @* Funding Sources *@
@@ -46,21 +78,21 @@
     {
         if (ViewDataTyped.Project.FundingTypeID == FundingType.BudgetVariesByYear.FundingTypeID)
         {
-            <div class="table-responsive tableFixHeader">
-                <table class="table table-condensed table-bordered">
+            <div class="table-responsive tableFixHeader" style="max-height: 600px;">
+                <table class="table table-condensed table-bordered tableFixedHead tableFixedFirstColumn">
                     <thead>
                         <tr>
-                            <th rowspan="2">
+                            <th rowspan="2" class="centeredWithTopBorder">
                                 <span> @Html.LabelWithSugarFor(ViewDataTyped.FieldDefinitionForFundingSource) / @Html.LabelWithSugarFor(ViewDataTyped.FieldDefinitionForCostType)</span>
                             </th>
                             @foreach (var calendarYear in @ViewDataTyped.CalendarYears)
                             {
 
-                                <th colspan="3" style="text-align: center">
+                                <th colspan="3" class="centeredWithTopBorder">
                                     <span>@calendarYear</span>
                                 </th>
                             }
-                            <th colspan="3" style="text-align: center">Totals</th>
+                            <th colspan="3" class="centeredWithTopBorder">Totals</th>
                         </tr>
                         <tr>
                             @foreach (var calendarYear in @ViewDataTyped.CalendarYears)
@@ -93,7 +125,8 @@
                             var currentFundingSource = groupedByFundingSource.First().FundingSource;
 
                             <tr class="info">
-                                <td style="text-align: left; white-space: nowrap;" colspan="@(ViewDataTyped.CalendarYears.Count * 3 + 4)">@Html.Raw(currentFundingSource.GetDisplayNameAsUrl())</td>
+                                <td style="text-align: left; white-space: nowrap; border-right: 0;" colspan="4">@Html.Raw(currentFundingSource.GetDisplayNameAsUrl())</td>
+                                <td style="text-align: left; white-space: nowrap; border-left: 0;" colspan="@(ViewDataTyped.CalendarYears.Count * 3)"></td>
                             </tr>
                             foreach (var groupedByCostType in groupedByFundingSource.GroupBy(x => x.CostType).OrderBy(x => GetCostTypeNameOrNullString(x.Key)))
                             {
@@ -130,7 +163,7 @@
 
                         }
                         <tr>
-                            <th style="text-align: left">Grand Total</th>
+                            <td style="text-align: left; font-weight: bold;">Grand Total</td>
                             @foreach (var calendarYear in ViewDataTyped.CalendarYears)
                             {
                                 <th class="text-right">
@@ -160,7 +193,7 @@
             <h4>@FieldDefinitionEnum.NoFundingSourceIdentified.ToType().GetFieldDefinitionLabel()</h4>
             @* No Funding Source Identified Funds for per year budget *@
             <div class="table-responsive tableFixHeader">
-                <table class="table table-condensed table-bordered">
+                <table class="table table-condensed table-bordered tableFixedFirstColumn">
                     <thead>
                         <tr>
                             <th>
@@ -200,7 +233,7 @@
 
                         
                         <tr>
-                            <th style="text-align: left">Grand Total</th>
+                            <td style="text-align: left; font-weight: bold;">Grand Total</td>
                             @foreach (var calendarYear in ViewDataTyped.CalendarYears)
                             {
                                 <th class="text-right">

--- a/Source/ProjectFirma.Web/Views/Shared/ProjectRunningBalanceObligationsAndExpenditures/ProjectRunningBalanceObligationsAndExpenditures.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectRunningBalanceObligationsAndExpenditures/ProjectRunningBalanceObligationsAndExpenditures.cshtml
@@ -41,8 +41,9 @@
 }
 
 <style>
+    table.tableFixedHead { border-collapse: separate; }
     .tableFixedHead tbody { overflow-y: auto; height: 300px; }
-    .tableFixedHead thead th { position: sticky; top: 0; background-color: #fff; }
+    .tableFixedHead thead th { position: sticky; top: 0; background-color: #fff; border-top: 1px solid #ddd !important; }
 </style>
     <div class="table-responsive" style="max-height: 450px;">
         <table class="table table-condensed table-bordered tableFixedHead">

--- a/Source/ProjectFirma.Web/Views/Shared/ProjectRunningBalanceObligationsAndExpenditures/ProjectRunningBalanceObligationsAndExpenditures.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectRunningBalanceObligationsAndExpenditures/ProjectRunningBalanceObligationsAndExpenditures.cshtml
@@ -42,7 +42,7 @@
 
 <style>
     table.tableFixedHead { border-collapse: separate; }
-    .tableFixedHead tbody { overflow-y: auto; height: 300px; }
+    .tableFixedHead tbody { overflow-y: auto; }
     .tableFixedHead thead th { position: sticky; top: 0; background-color: #fff; border-top: 1px solid #ddd !important; }
 </style>
     <div class="table-responsive" style="max-height: 450px;">


### PR DESCRIPTION
Luckily the new and edit/update displays for the funding source were the same, so the changes are largely in two view files: the shared view and the edit form.

Some of the changes involve moving the trash icon in with the funding source label so that the sticky first cell for those rows would have the label information and not just the icon.